### PR TITLE
Refactoring&Design Pattern: Singleton Design Pattern, Encapsulate Field, Create Instance with type

### DIFF
--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Amulet.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Amulet.java
@@ -74,7 +74,7 @@ public class Amulet extends Item {
 			
 			if (!Statistics.amuletObtained) {
 				Statistics.amuletObtained = true;
-				hero.spend(-TIME_TO_PICK_UP);
+				hero.spend(-getTIME_TO_PICK_UP());
 
 				//add a delayed actor here so pickup behaviour can fully process.
 				Actor.addDelayed(new Actor(){

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Dewdrop.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Dewdrop.java
@@ -65,7 +65,7 @@ public class Dewdrop extends Item {
 		}
 		
 		Sample.INSTANCE.play( Assets.Sounds.DEWDROP );
-		hero.spendAndNext( TIME_TO_PICK_UP );
+		hero.spendAndNext(getTIME_TO_PICK_UP());
 		
 		return true;
 	}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/EnergyCrystal.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/EnergyCrystal.java
@@ -61,7 +61,7 @@ public class EnergyCrystal extends Item {
 
 		GameScene.pickUp( this, pos );
 		hero.sprite.showStatus( 0x44CCFF, TXT_VALUE, quantity );
-		hero.spendAndNext( TIME_TO_PICK_UP );
+		hero.spendAndNext(getTIME_TO_PICK_UP());
 
 		Sample.INSTANCE.play( Assets.Sounds.ITEM );
 

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Gold.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Gold.java
@@ -26,7 +26,6 @@ import com.shatteredpixel.shatteredpixeldungeon.Badges;
 import com.shatteredpixel.shatteredpixeldungeon.Dungeon;
 import com.shatteredpixel.shatteredpixeldungeon.Statistics;
 import com.shatteredpixel.shatteredpixeldungeon.actors.hero.Hero;
-import com.shatteredpixel.shatteredpixeldungeon.items.artifacts.MasterThievesArmband;
 import com.shatteredpixel.shatteredpixeldungeon.scenes.GameScene;
 import com.shatteredpixel.shatteredpixeldungeon.sprites.CharSprite;
 import com.shatteredpixel.shatteredpixeldungeon.sprites.ItemSpriteSheet;
@@ -66,7 +65,7 @@ public class Gold extends Item {
 
 		GameScene.pickUp( this, pos );
 		hero.sprite.showStatus( CharSprite.NEUTRAL, TXT_VALUE, quantity );
-		hero.spendAndNext( TIME_TO_PICK_UP );
+		hero.spendAndNext(getTIME_TO_PICK_UP());
 		
 		Sample.INSTANCE.play( Assets.Sounds.GOLD, 1, 1, Random.Float( 0.9f, 1.1f ) );
 		updateQuickslot();

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Honeypot.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Honeypot.java
@@ -45,7 +45,7 @@ public class Honeypot extends Item {
 	{
 		image = ItemSpriteSheet.HONEYPOT;
 
-		defaultAction = AC_THROW;
+		defaultAction = getAC_THROW();
 		usesTargeting = true;
 
 		stackable = true;

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Item.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Item.java
@@ -43,7 +43,6 @@ import com.shatteredpixel.shatteredpixeldungeon.scenes.CellSelector;
 import com.shatteredpixel.shatteredpixeldungeon.scenes.GameScene;
 import com.shatteredpixel.shatteredpixeldungeon.sprites.ItemSprite;
 import com.shatteredpixel.shatteredpixeldungeon.sprites.MissileSprite;
-import com.shatteredpixel.shatteredpixeldungeon.ui.InventoryPane;
 import com.shatteredpixel.shatteredpixeldungeon.ui.QuickSlotButton;
 import com.watabou.noosa.audio.Sample;
 import com.watabou.noosa.particles.Emitter;
@@ -58,15 +57,15 @@ import java.util.Comparator;
 
 public class Item implements Bundlable {
 
-	protected static final String TXT_TO_STRING_LVL		= "%s %+d";
-	protected static final String TXT_TO_STRING_X		= "%s x%d";
+	private static final String TXT_TO_STRING_LVL		= "%s %+d";
+	private static final String TXT_TO_STRING_X		= "%s x%d";
 	
-	protected static final float TIME_TO_THROW		= 1.0f;
-	protected static final float TIME_TO_PICK_UP	= 1.0f;
-	protected static final float TIME_TO_DROP		= 1.0f;
+	private static final float TIME_TO_THROW		= 1.0f;
+	private static final float TIME_TO_PICK_UP	= 1.0f;
+	private static final float TIME_TO_DROP		= 1.0f;
 	
-	public static final String AC_DROP		= "DROP";
-	public static final String AC_THROW		= "THROW";
+	private static final String AC_DROP		= "DROP";
+	private static final String AC_THROW		= "THROW";
 	
 	protected String defaultAction;
 	public boolean usesTargeting;
@@ -101,11 +100,39 @@ public class Item implements Bundlable {
 			return Generator.Category.order( lhs ) - Generator.Category.order( rhs );
 		}
 	};
-	
+
+	public static String getTXT_TO_STRING_LVL() {
+		return TXT_TO_STRING_LVL;
+	}
+
+	public static String getTXT_TO_STRING_X() {
+		return TXT_TO_STRING_X;
+	}
+
+	public static float getTIME_TO_THROW() {
+		return TIME_TO_THROW;
+	}
+
+	public static float getTIME_TO_PICK_UP() {
+		return TIME_TO_PICK_UP;
+	}
+
+	public static float getTIME_TO_DROP() {
+		return TIME_TO_DROP;
+	}
+
+	public static String getAC_DROP() {
+		return AC_DROP;
+	}
+
+	public static String getAC_THROW() {
+		return AC_THROW;
+	}
+
 	public ArrayList<String> actions( Hero hero ) {
 		ArrayList<String> actions = new ArrayList<>();
-		actions.add( AC_DROP );
-		actions.add( AC_THROW );
+		actions.add(getAC_DROP());
+		actions.add(getAC_THROW());
 		return actions;
 	}
 
@@ -122,7 +149,7 @@ public class Item implements Bundlable {
 			
 			GameScene.pickUp( this, pos );
 			Sample.INSTANCE.play( Assets.Sounds.ITEM );
-			hero.spendAndNext( TIME_TO_PICK_UP );
+			hero.spendAndNext(getTIME_TO_PICK_UP());
 			return true;
 			
 		} else {
@@ -131,7 +158,7 @@ public class Item implements Bundlable {
 	}
 	
 	public void doDrop( Hero hero ) {
-		hero.spendAndNext(TIME_TO_DROP);
+		hero.spendAndNext(getTIME_TO_DROP());
 		int pos = hero.pos;
 		Dungeon.level.drop(detachAll(hero.belongings.backpack), pos).sprite.drop(pos);
 	}
@@ -151,13 +178,13 @@ public class Item implements Bundlable {
 		curUser = hero;
 		curItem = this;
 		
-		if (action.equals( AC_DROP )) {
+		if (action.equals(getAC_DROP())) {
 			
 			if (hero.belongings.backpack.contains(this) || isEquipped(hero)) {
 				doDrop(hero);
 			}
 			
-		} else if (action.equals( AC_THROW )) {
+		} else if (action.equals(getAC_THROW())) {
 			
 			if (hero.belongings.backpack.contains(this) || isEquipped(hero)) {
 				doThrow(hero);
@@ -457,10 +484,10 @@ public class Item implements Bundlable {
 		String name = name();
 
 		if (visiblyUpgraded() != 0)
-			name = Messages.format( TXT_TO_STRING_LVL, name, visiblyUpgraded()  );
+			name = Messages.format(getTXT_TO_STRING_LVL(), name, visiblyUpgraded()  );
 
 		if (quantity > 1)
-			name = Messages.format( TXT_TO_STRING_X, name, quantity );
+			name = Messages.format(getTXT_TO_STRING_X(), name, quantity );
 
 		return name;
 
@@ -649,7 +676,7 @@ public class Item implements Bundlable {
 	}
 	
 	public float castDelay( Char user, int dst ){
-		return TIME_TO_THROW;
+		return getTIME_TO_THROW();
 	}
 	
 	protected static Hero curUser = null;

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/LostBackpack.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/LostBackpack.java
@@ -73,7 +73,7 @@ public class LostBackpack extends Item {
 
 		Item.updateQuickslot();
 		Sample.INSTANCE.play( Assets.Sounds.DEWDROP );
-		hero.spendAndNext(TIME_TO_PICK_UP);
+		hero.spendAndNext(getTIME_TO_PICK_UP());
 		GameScene.pickUp( this, pos );
 		((HeroSprite)hero.sprite).updateArmor();
 		return true;

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Recipe.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Recipe.java
@@ -26,6 +26,7 @@ import com.shatteredpixel.shatteredpixeldungeon.items.bombs.Bomb;
 import com.shatteredpixel.shatteredpixeldungeon.items.food.Blandfruit;
 import com.shatteredpixel.shatteredpixeldungeon.items.food.MeatPie;
 import com.shatteredpixel.shatteredpixeldungeon.items.food.StewedMeat;
+import com.shatteredpixel.shatteredpixeldungeon.items.food.StewedMeatEnum;
 import com.shatteredpixel.shatteredpixeldungeon.items.potions.AlchemicalCatalyst;
 import com.shatteredpixel.shatteredpixeldungeon.items.potions.Potion;
 import com.shatteredpixel.shatteredpixeldungeon.items.potions.brews.BlizzardBrew;
@@ -175,7 +176,7 @@ public abstract class Recipe {
 		new ExoticScroll.ScrollToExotic(),
 		new ArcaneResin.Recipe(),
 		new Alchemize.Recipe(),
-		new StewedMeat.oneMeat()
+		new StewedMeat.StewedMeatRecipe(StewedMeatEnum.STEWED_MEAT_ONE)
 	};
 	
 	private static Recipe[] twoIngredientRecipes = new Recipe[]{
@@ -205,12 +206,12 @@ public abstract class Recipe {
 		new WildEnergy.Recipe(),
 		new TelekineticGrab.Recipe(),
 		new SummonElemental.Recipe(),
-		new StewedMeat.twoMeat()
+		new StewedMeat.StewedMeatRecipe(StewedMeatEnum.STEWED_MEAT_TWO)
 	};
 	
 	private static Recipe[] threeIngredientRecipes = new Recipe[]{
 		new Potion.SeedToPotion(),
-		new StewedMeat.threeMeat(),
+		new StewedMeat.StewedMeatRecipe(StewedMeatEnum.STEWED_MEAT_THREE),
 		new MeatPie.Recipe()
 	};
 	

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/artifacts/DriedRose.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/artifacts/DriedRose.java
@@ -488,7 +488,7 @@ public class DriedRose extends Artifact {
 				return false;
 			} if ( rose.level() >= rose.levelCap ){
 				GLog.i( Messages.get(this, "no_room") );
-				hero.spendAndNext(TIME_TO_PICK_UP);
+				hero.spendAndNext(getTIME_TO_PICK_UP());
 				return true;
 			} else {
 
@@ -500,7 +500,7 @@ public class DriedRose extends Artifact {
 
 				Sample.INSTANCE.play( Assets.Sounds.DEWDROP );
 				GameScene.pickUp(this, pos);
-				hero.spendAndNext(TIME_TO_PICK_UP);
+				hero.spendAndNext(getTIME_TO_PICK_UP());
 				return true;
 
 			}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/artifacts/MasterThievesArmband.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/artifacts/MasterThievesArmband.java
@@ -39,17 +39,13 @@ import com.shatteredpixel.shatteredpixeldungeon.actors.mobs.npcs.Shopkeeper;
 import com.shatteredpixel.shatteredpixeldungeon.effects.Surprise;
 import com.shatteredpixel.shatteredpixeldungeon.items.Item;
 import com.shatteredpixel.shatteredpixeldungeon.items.rings.RingOfEnergy;
-import com.shatteredpixel.shatteredpixeldungeon.mechanics.Ballistica;
 import com.shatteredpixel.shatteredpixeldungeon.messages.Messages;
 import com.shatteredpixel.shatteredpixeldungeon.scenes.CellSelector;
 import com.shatteredpixel.shatteredpixeldungeon.scenes.GameScene;
 import com.shatteredpixel.shatteredpixeldungeon.sprites.ItemSpriteSheet;
-import com.shatteredpixel.shatteredpixeldungeon.utils.BArray;
 import com.shatteredpixel.shatteredpixeldungeon.utils.GLog;
 import com.watabou.noosa.audio.Sample;
-import com.watabou.utils.Bundle;
 import com.watabou.utils.Callback;
-import com.watabou.utils.PathFinder;
 import com.watabou.utils.Random;
 
 import java.util.ArrayList;
@@ -166,7 +162,7 @@ public class MasterThievesArmband extends Artifact {
 								} else {
 									if (loot.doPickUp(curUser)) {
 										//item collection happens instantly
-										curUser.spend(-TIME_TO_PICK_UP);
+										curUser.spend(-getTIME_TO_PICK_UP());
 									} else {
 										Dungeon.level.drop(loot, curUser.pos).sprite.drop();
 									}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/artifacts/TimekeepersHourglass.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/artifacts/TimekeepersHourglass.java
@@ -474,7 +474,7 @@ public class TimekeepersHourglass extends Artifact {
 				else
 					GLog.i( Messages.get(this, "levelup") );
 				GameScene.pickUp(this, pos);
-				hero.spendAndNext(TIME_TO_PICK_UP);
+				hero.spendAndNext(getTIME_TO_PICK_UP());
 				return true;
 			} else {
 				GLog.w( Messages.get(this, "no_hourglass") );

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/bombs/Bomb.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/bombs/Bomb.java
@@ -100,7 +100,7 @@ public class Bomb extends Item {
 
 		if (action.equals(AC_LIGHTTHROW)) {
 			lightingFuse = true;
-			action = AC_THROW;
+			action = getAC_THROW();
 		} else
 			lightingFuse = false;
 

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/food/Pasty.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/food/Pasty.java
@@ -24,22 +24,29 @@ package com.shatteredpixel.shatteredpixeldungeon.items.food;
 import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Hunger;
 
 public class Pasty extends Food {
-	//TODO: implement fun stuff for other holidays
-	//TODO: probably should externalize this if I want to add any more festive stuff.
-	protected static HolidayEnum holiday;
+    // TODO: implement fun stuff for other holidays
+    // TODO: probably should externalize this if I want to add any more festive stuff.
+
+    private static final Pasty pasty;
+    private static final HolidayEnum holiday;
+
     static {
         holiday = Holiday.getHoliday();
     }
 
-	{
-		reset();
+    static {
+        pasty = createInstanceInternal();
+    }
 
-		energy = Hunger.STARVING;
+    {
+        reset();
+        energy = Hunger. STARVING;
+        bones = true;
+    }
 
-		bones = true;
-	}
+    protected Pasty() {}
 
-    public static Pasty createInstance() { // singleton
+    private static Pasty createInstanceInternal() {
         switch (holiday) {
             case NONE:
                 return new PastyNONE();
@@ -50,5 +57,9 @@ public class Pasty extends Food {
             default:
                 throw new IllegalArgumentException("Invalid holiday value: " + holiday);
         }
+    }
+
+    public static Pasty createInstance() {
+        return pasty;
     }
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/food/StewedMeat.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/food/StewedMeat.java
@@ -44,7 +44,11 @@ public class StewedMeat extends Food {
 			inputs = new Class[]{MysteryMeat.class};
 			inQuantity = new int[]{quantityIntValue};
 
-			cost = quantityIntValue;
+			if(quantityIntValue == 3) {
+				cost = 2;
+			} else {
+				cost = quantityIntValue;
+			}
 
 			output = StewedMeat.class;
 			outQuantity = quantityIntValue;

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/food/StewedMeat.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/food/StewedMeat.java
@@ -26,54 +26,28 @@ import com.shatteredpixel.shatteredpixeldungeon.items.Recipe;
 import com.shatteredpixel.shatteredpixeldungeon.sprites.ItemSpriteSheet;
 
 public class StewedMeat extends Food {
-	
+
 	{
 		image = ItemSpriteSheet.STEWED;
 		energy = Hunger.HUNGRY/2f;
 	}
-	
+
 	@Override
 	public int value() {
 		return 8 * quantity;
 	}
-	
-	public static class oneMeat extends Recipe.SimpleRecipe{
-		{
-			inputs =  new Class[]{MysteryMeat.class};
-			inQuantity = new int[]{1};
-			
-			cost = 1;
-			
-			output = StewedMeat.class;
-			outQuantity = 1;
-		}
-	}
-	
-	public static class twoMeat extends Recipe.SimpleRecipe{
-		{
-			inputs =  new Class[]{MysteryMeat.class};
-			inQuantity = new int[]{2};
-			
-			cost = 2;
-			
-			output = StewedMeat.class;
-			outQuantity = 2;
-		}
-	}
-	
-	//red meat
-	//blue meat
-	
-	public static class threeMeat extends Recipe.SimpleRecipe{
-		{
-			inputs =  new Class[]{MysteryMeat.class};
-			inQuantity = new int[]{3};
-			
-			cost = 2;
-			
-			output = StewedMeat.class;
-			outQuantity = 3;
-		}
-	}
 
+	public static class StewedMeatRecipe extends Recipe.SimpleRecipe {
+		public StewedMeatRecipe(StewedMeatEnum quantity) {
+			int quantityIntValue = quantity.ordinal(); // Convert enum value to int
+
+			inputs = new Class[]{MysteryMeat.class};
+			inQuantity = new int[]{quantityIntValue};
+
+			cost = quantityIntValue;
+
+			output = StewedMeat.class;
+			outQuantity = quantityIntValue;
+		}
+	}
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/food/StewedMeatEnum.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/food/StewedMeatEnum.java
@@ -1,0 +1,20 @@
+package com.shatteredpixel.shatteredpixeldungeon.items.food;
+
+public enum StewedMeatEnum {
+    STEWED_MEAT_ONE(1),
+    STEWED_MEAT_TWO(2),
+    STEWED_MEAT_THREE(3);
+
+    private final int quantity;
+
+    StewedMeatEnum(int quantity) {
+        if (quantity < 1 || quantity > 3) {
+            throw new IllegalArgumentException("StewedMeat Quantity value must be between 1 and 3.");
+        }
+        this.quantity = quantity;
+    }
+
+    public int getQuantity() {
+        return quantity;
+    }
+}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/journal/DocumentPage.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/journal/DocumentPage.java
@@ -61,7 +61,7 @@ public abstract class DocumentPage extends Item {
 		}
 		document().findPage(page);
 		Sample.INSTANCE.play( Assets.Sounds.ITEM );
-		hero.spendAndNext( TIME_TO_PICK_UP );
+		hero.spendAndNext(getTIME_TO_PICK_UP());
 		return true;
 	}
 

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/journal/Guidebook.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/journal/Guidebook.java
@@ -54,7 +54,7 @@ public class Guidebook extends Item {
 		GLog.p(Messages.get(GameScene.class, "tutorial_guidebook"));
 		GameScene.flashForDocument(Document.ADVENTURERS_GUIDE, Document.GUIDE_INTRO);
 		Sample.INSTANCE.play( Assets.Sounds.ITEM );
-		hero.spendAndNext( TIME_TO_PICK_UP );
+		hero.spendAndNext(getTIME_TO_PICK_UP());
 		return true;
 	}
 

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/keys/Key.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/keys/Key.java
@@ -52,7 +52,7 @@ public abstract class Key extends Item {
 		WndJournal.last_index = 2;
 		Notes.add(this);
 		Sample.INSTANCE.play( Assets.Sounds.ITEM );
-		hero.spendAndNext( TIME_TO_PICK_UP );
+		hero.spendAndNext(getTIME_TO_PICK_UP());
 		GameScene.updateKeyDisplay();
 		return true;
 	}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/potions/Potion.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/potions/Potion.java
@@ -35,7 +35,6 @@ import com.shatteredpixel.shatteredpixeldungeon.items.Generator;
 import com.shatteredpixel.shatteredpixeldungeon.items.Item;
 import com.shatteredpixel.shatteredpixeldungeon.items.ItemStatusHandler;
 import com.shatteredpixel.shatteredpixeldungeon.items.Recipe;
-import com.shatteredpixel.shatteredpixeldungeon.items.bags.Bag;
 import com.shatteredpixel.shatteredpixeldungeon.items.potions.elixirs.ElixirOfHoneyedHealing;
 import com.shatteredpixel.shatteredpixeldungeon.items.potions.exotic.ExoticPotion;
 import com.shatteredpixel.shatteredpixeldungeon.items.potions.exotic.PotionOfCleansing;
@@ -197,7 +196,7 @@ public class Potion extends Item {
 	@Override
 	public String defaultAction() {
 		if (isKnown() && mustThrowPots.contains(this.getClass())) {
-			return AC_THROW;
+			return getAC_THROW();
 		} else if (isKnown() &&canThrowPots.contains(this.getClass())){
 			return AC_CHOOSE;
 		} else {

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/potions/brews/Brew.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/potions/brews/Brew.java
@@ -38,7 +38,7 @@ public abstract class Brew extends Potion {
 
 	@Override
 	public String defaultAction() {
-		return AC_THROW;
+		return getAC_THROW();
 	}
 	
 	@Override

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/quest/CeremonialCandle.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/quest/CeremonialCandle.java
@@ -52,7 +52,7 @@ public class CeremonialCandle extends Item {
 	{
 		image = ItemSpriteSheet.CANDLE;
 
-		defaultAction = AC_THROW;
+		defaultAction = getAC_THROW();
 
 		unique = true;
 		stackable = true;

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/spells/ReclaimTrap.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/spells/ReclaimTrap.java
@@ -27,7 +27,6 @@ import com.shatteredpixel.shatteredpixeldungeon.actors.hero.Hero;
 import com.shatteredpixel.shatteredpixeldungeon.items.quest.MetalShard;
 import com.shatteredpixel.shatteredpixeldungeon.items.scrolls.ScrollOfMagicMapping;
 import com.shatteredpixel.shatteredpixeldungeon.items.scrolls.ScrollOfRecharging;
-import com.shatteredpixel.shatteredpixeldungeon.levels.traps.SummoningTrap;
 import com.shatteredpixel.shatteredpixeldungeon.levels.traps.Trap;
 import com.shatteredpixel.shatteredpixeldungeon.mechanics.Ballistica;
 import com.shatteredpixel.shatteredpixeldungeon.messages.Messages;
@@ -53,8 +52,8 @@ public class ReclaimTrap extends TargetedSpell {
 		ArrayList<String> actions = super.actions(hero);
 		//prevents exploits
 		if (storedTrap != null){
-			actions.remove(AC_DROP);
-			actions.remove(AC_THROW);
+			actions.remove(getAC_DROP());
+			actions.remove(getAC_THROW());
 		}
 		return actions;
 	}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/spells/TelekineticGrab.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/spells/TelekineticGrab.java
@@ -73,7 +73,7 @@ public class TelekineticGrab extends TargetedSpell {
 				Item item = ch.buff(PinCushion.class).grabOne();
 
 				if (item.doPickUp(hero, ch.pos)) {
-					hero.spend(-Item.TIME_TO_PICK_UP); //casting the spell already takes a turn
+					hero.spend(-Item.getTIME_TO_PICK_UP()); //casting the spell already takes a turn
 					GLog.i( Messages.capitalize(Messages.get(hero, "you_now_have", item.name())) );
 
 				} else {
@@ -98,7 +98,7 @@ public class TelekineticGrab extends TargetedSpell {
 				Item item = h.peek();
 				if (item.doPickUp(hero, h.pos)) {
 					h.pickUp();
-					hero.spend(-Item.TIME_TO_PICK_UP); //casting the spell already takes a turn
+					hero.spend(-Item.getTIME_TO_PICK_UP()); //casting the spell already takes a turn
 					GLog.i( Messages.capitalize(Messages.get(hero, "you_now_have", item.name())) );
 
 				} else {

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/stones/Runestone.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/stones/Runestone.java
@@ -30,7 +30,7 @@ public abstract class Runestone extends Item {
 	
 	{
 		stackable = true;
-		defaultAction = AC_THROW;
+		defaultAction = getAC_THROW();
 	}
 
 	//runestones press the cell they're thrown to by default, but a couple stones override this
@@ -38,7 +38,7 @@ public abstract class Runestone extends Item {
 
 	@Override
 	protected void onThrow(int cell) {
-		if (Dungeon.level.pit[cell] || !defaultAction().equals(AC_THROW)){
+		if (Dungeon.level.pit[cell] || !defaultAction().equals(getAC_THROW())){
 			super.onThrow( cell );
 		} else {
 			if (pressesCell) Dungeon.level.pressCell( cell );

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/weapon/missiles/HeavyBoomerang.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/weapon/missiles/HeavyBoomerang.java
@@ -27,7 +27,6 @@ import com.shatteredpixel.shatteredpixeldungeon.actors.Actor;
 import com.shatteredpixel.shatteredpixeldungeon.actors.Char;
 import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Buff;
 import com.shatteredpixel.shatteredpixeldungeon.actors.hero.Hero;
-import com.shatteredpixel.shatteredpixeldungeon.actors.hero.Talent;
 import com.shatteredpixel.shatteredpixeldungeon.sprites.ItemSpriteSheet;
 import com.shatteredpixel.shatteredpixeldungeon.sprites.MissileSprite;
 import com.watabou.noosa.tweeners.AlphaTweener;
@@ -127,7 +126,7 @@ public class HeavyBoomerang extends MissileWeapon {
 											if (returnTarget == target){
 												if (target instanceof Hero && boomerang.doPickUp((Hero) target)) {
 													//grabbing the boomerang takes no time
-													((Hero) target).spend(-TIME_TO_PICK_UP);
+													((Hero) target).spend(-getTIME_TO_PICK_UP());
 												} else {
 													Dungeon.level.drop(boomerang, returnPos).sprite.drop();
 												}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/weapon/missiles/MissileWeapon.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/weapon/missiles/MissileWeapon.java
@@ -35,12 +35,10 @@ import com.shatteredpixel.shatteredpixeldungeon.actors.hero.Talent;
 import com.shatteredpixel.shatteredpixeldungeon.items.Item;
 import com.shatteredpixel.shatteredpixeldungeon.items.bags.Bag;
 import com.shatteredpixel.shatteredpixeldungeon.items.bags.MagicalHolster;
-import com.shatteredpixel.shatteredpixeldungeon.items.rings.RingOfArcana;
 import com.shatteredpixel.shatteredpixeldungeon.items.rings.RingOfSharpshooting;
 import com.shatteredpixel.shatteredpixeldungeon.items.weapon.SpiritBow;
 import com.shatteredpixel.shatteredpixeldungeon.items.weapon.Weapon;
 import com.shatteredpixel.shatteredpixeldungeon.items.weapon.enchantments.Projecting;
-import com.shatteredpixel.shatteredpixeldungeon.items.weapon.melee.Scimitar;
 import com.shatteredpixel.shatteredpixeldungeon.items.weapon.missiles.darts.Dart;
 import com.shatteredpixel.shatteredpixeldungeon.messages.Messages;
 import com.shatteredpixel.shatteredpixeldungeon.sprites.ItemSpriteSheet;
@@ -58,7 +56,7 @@ abstract public class MissileWeapon extends Weapon {
 		
 		bones = true;
 
-		defaultAction = AC_THROW;
+		defaultAction = getAC_THROW();
 		usesTargeting = true;
 	}
 	

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/plants/Plant.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/plants/Plant.java
@@ -132,7 +132,7 @@ public abstract class Plant implements Bundlable {
 		
 		{
 			stackable = true;
-			defaultAction = AC_THROW;
+			defaultAction = getAC_THROW();
 		}
 		
 		protected Class<? extends Plant> plantClass;

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/ui/QuickRecipe.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/ui/QuickRecipe.java
@@ -29,12 +29,7 @@ import com.shatteredpixel.shatteredpixeldungeon.items.Item;
 import com.shatteredpixel.shatteredpixeldungeon.items.LiquidMetal;
 import com.shatteredpixel.shatteredpixeldungeon.items.Recipe;
 import com.shatteredpixel.shatteredpixeldungeon.items.bombs.Bomb;
-import com.shatteredpixel.shatteredpixeldungeon.items.food.Blandfruit;
-import com.shatteredpixel.shatteredpixeldungeon.items.food.Food;
-import com.shatteredpixel.shatteredpixeldungeon.items.food.MeatPie;
-import com.shatteredpixel.shatteredpixeldungeon.items.food.MysteryMeat;
-import com.shatteredpixel.shatteredpixeldungeon.items.food.Pasty;
-import com.shatteredpixel.shatteredpixeldungeon.items.food.StewedMeat;
+import com.shatteredpixel.shatteredpixeldungeon.items.food.*;
 import com.shatteredpixel.shatteredpixeldungeon.items.potions.AlchemicalCatalyst;
 import com.shatteredpixel.shatteredpixeldungeon.items.potions.Potion;
 import com.shatteredpixel.shatteredpixeldungeon.items.potions.brews.BlizzardBrew;
@@ -284,9 +279,9 @@ public class QuickRecipe extends Component {
 				}
 				return result;
 			case 2:
-				result.add(new QuickRecipe( new StewedMeat.oneMeat() ));
-				result.add(new QuickRecipe( new StewedMeat.twoMeat() ));
-				result.add(new QuickRecipe( new StewedMeat.threeMeat() ));
+				result.add(new QuickRecipe( new StewedMeat.StewedMeatRecipe(StewedMeatEnum.STEWED_MEAT_ONE) ));
+				result.add(new QuickRecipe( new StewedMeat.StewedMeatRecipe(StewedMeatEnum.STEWED_MEAT_TWO) ));
+				result.add(new QuickRecipe( new StewedMeat.StewedMeatRecipe(StewedMeatEnum.STEWED_MEAT_THREE) ));
 				result.add(null);
 				result.add(new QuickRecipe( new MeatPie.Recipe(),
 						new ArrayList<Item>(Arrays.asList(Pasty.createInstance(), new Food(), new MysteryMeat.PlaceHolder())),


### PR DESCRIPTION
# Singleton Design Pattern
# Items/Food/Pasty.java_신다윗
Date: 2023.05.24~2023.05.25
Manager: 신다윗
Status: Done
Writer: 신다윗
Work Type: Singleton Design Pattern
# Commit Message
Singleton Design Pattern: Facilitating sharing resources
# 패턴에 대한 설명
Singleton Design Pattern
After the pasty class is created once, it is initialized as static and there is no need to continuously create it.
When shared as a single instance, resources can be used efficiently.
So I wanted to apply the Singleton Design Pattern.
After the pasty class is created once, it is initialized as static and there is no need to continuously create it.
When shared as a single instance, resources can be used efficiently.
So I wanted to apply the Singleton Design Pattern.
So, I added a method to create SubClass in Pasty Class.
And the reason Pasty's constructor was set to protected instead of private is because SubClass uses it.
By setting the constructor as protected, you can induce the use of the createInstance() method because Pasty's constructor cannot be used from the outside.
- Pasty.java
# 수행 이유
Can ensure that a class has just a single instance.
Can provide a global access point to that instance.
# Effect
The singleton object is initialized only when it’s requested for the first time.
Can be sure that a class has only a single instance.
- Can gain a global access point to that instance.
- Can't cause issues or unnecessary duplication of resources.
- Can facilitate sharing resources among multiple parts of the application.
# 수행 대상
Items/Food/Pasty.java
# 전/후 Diagram
<img src="https://file.notion.so/f/s/31938635-d33b-4674-82ed-7faac559e2e6/PastyDiagramAfter.png?id=9e83068e-161f-4cc1-9d9d-c8d10870f5dc&table=block&spaceId=7d682076-1dd7-42aa-abd7-a3f8dd1751c4&expirationTimestamp=1685179041450&signature=2l7OLqa-qPEXpA18IXICBqtcwj_IauzgT8Rs7m8NWmk&downloadName=PastyDiagramAfter.png" />
The diagram of the Item Class is too long, so I omitted it.
The method below has been added in Pasty.
- Protected Constructor
- private static Pasty createInstanceInternal()
- public static Pasty createInstance()
<img src="https://file.notion.so/f/s/4d4e17ad-0872-471f-b001-6e033ed25c12/PastyDiagramSingleton.png?id=a9c1756c-2b89-4211-a2db-a16668511adc&table=block&spaceId=7d682076-1dd7-42aa-abd7-a3f8dd1751c4&expirationTimestamp=1685179044204&signature=YAfGzFH1qduQO_iNEO6Wdl1op4UWUXea337DJhxCJEg&downloadName=PastyDiagramSingleton.png" />

# reference  
[Singleton](https://refactoring.guru/design-patterns/singleton/java/example)

<hr>

# Encapsulate Field
# Items/Item_신다윗
Date: 2023.05.26~2023.05.27
Manager: 신다윗
Status: Done
Writer: 신다윗
Work Type: Encapsulate Field for immutable Fields: Encapsulation, Maintainability
# Commit Message
Encapsulate Field for immutable Fields: Encapsulation, Maintainability
# 패턴에 대한 설명
Encapsulate Field for immutable Fields: Encapsulation, Maintainability
- Item.java
# 수행 이유
I tried to distinguish between mutable and immutable fields in the field of item class and separate field class and method class. However, it failed in the process of refactoring the mutable field.  
So, only immutable fields were refactored into getter methods.  

Encapsulate Field is to create getter and setter methods for fields in the class.
There are two types of Field: Immutable and Mutable.
It depends on whether the value changes or not. Same as Final in Java.
I only made a getter method for Immutable, but the reason why I didn't make a setter method is because the value doesn't change.
Of course, I could have created a getter method and setter method for mutable, but I didn't.
The initial purpose was to separate into method classes, but the moment I tried to touch the method, I thought about whether I could refactor for about 3 weeks and thought it was not possible.
This is because there were cases where fields and methods were used and overridden in numerous classes, or the Item class was used as a field.
Many other classes are too difficult to figure out the relationship with the Item Class.
# Effect
can enforce encapsulation and maintain the principle of data hiding.
# 수행 대상
- Item.java
# 전/후 Diagram
생략
# Reference  
[Encapsulate Field](https://refactoring.guru/ko/encapsulate-field)

<hr>

# Build Design Pattern
# Items/Food_신다윗
Date: 2023.05.28~2023.05.28
Manager: 신다윗
Status: Done
Writer: 신다윗
Work Type: Refactoring: Produce different types of an object using the same construction code.
# Commit Message
Refactoring: Produce different types of an object using the same construction code.
# 패턴에 대한 설명
Refactoring: Produce different types of an object using the same construction code.
- StewedMeat.java
- StewedMeatEnum.java
# 수행 이유
In StewedMeat, there was a code that creates a Recipe according to the Quantity of Meat.  
I tried to resolve this duplication because the constructing code was the same except for Quantity. 
# Effect
Can reuse the same construction code when Instance Class with type of products.
# 수행 대상
StewedMeat.java
- StewedMeatEnum.java
- Recipe.java
- QuickRecipe.java
# 전/후 Diagram
<img src="https://file.notion.so/f/s/0572f089-0718-4256-9327-2582ba689c58/StewedMeatBefore.png?id=24fa17e4-09cb-4d51-a2af-e5c29d397c1c&table=block&spaceId=7d682076-1dd7-42aa-abd7-a3f8dd1751c4&expirationTimestamp=1685418350492&signature=maNgubFR-bOApDo-G3rjvAB-ejiatU6dGeLgzQEU8T0&downloadName=StewedMeatBefore.png" />
<img src="https://file.notion.so/f/s/fbd8ab15-b552-4fcb-a362-6e01c8731712/StewedMeatAfter.png?id=28a7671a-cc0c-47af-af27-1598bd243229&table=block&spaceId=7d682076-1dd7-42aa-abd7-a3f8dd1751c4&expirationTimestamp=1685410959095&signature=7WVpmE1RRPXANc7J8-S9CdcFAt5fxOHFRz9eTnQDpd4&downloadName=StewedMeatAfter.png" />

# Reference  
[Builder](https://refactoring.guru/design-patterns/builder)