### PR TITLE
Encapsulate Field for immutable Fields: Encapsulation, Maintainability

### DIFF
--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Amulet.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Amulet.java
@@ -74,7 +74,7 @@ public class Amulet extends Item {
 			
 			if (!Statistics.amuletObtained) {
 				Statistics.amuletObtained = true;
-				hero.spend(-TIME_TO_PICK_UP);
+				hero.spend(-getTIME_TO_PICK_UP());
 
 				//add a delayed actor here so pickup behaviour can fully process.
 				Actor.addDelayed(new Actor(){

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Dewdrop.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Dewdrop.java
@@ -65,7 +65,7 @@ public class Dewdrop extends Item {
 		}
 		
 		Sample.INSTANCE.play( Assets.Sounds.DEWDROP );
-		hero.spendAndNext( TIME_TO_PICK_UP );
+		hero.spendAndNext(getTIME_TO_PICK_UP());
 		
 		return true;
 	}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/EnergyCrystal.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/EnergyCrystal.java
@@ -61,7 +61,7 @@ public class EnergyCrystal extends Item {
 
 		GameScene.pickUp( this, pos );
 		hero.sprite.showStatus( 0x44CCFF, TXT_VALUE, quantity );
-		hero.spendAndNext( TIME_TO_PICK_UP );
+		hero.spendAndNext(getTIME_TO_PICK_UP());
 
 		Sample.INSTANCE.play( Assets.Sounds.ITEM );
 

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Gold.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Gold.java
@@ -26,7 +26,6 @@ import com.shatteredpixel.shatteredpixeldungeon.Badges;
 import com.shatteredpixel.shatteredpixeldungeon.Dungeon;
 import com.shatteredpixel.shatteredpixeldungeon.Statistics;
 import com.shatteredpixel.shatteredpixeldungeon.actors.hero.Hero;
-import com.shatteredpixel.shatteredpixeldungeon.items.artifacts.MasterThievesArmband;
 import com.shatteredpixel.shatteredpixeldungeon.scenes.GameScene;
 import com.shatteredpixel.shatteredpixeldungeon.sprites.CharSprite;
 import com.shatteredpixel.shatteredpixeldungeon.sprites.ItemSpriteSheet;
@@ -66,7 +65,7 @@ public class Gold extends Item {
 
 		GameScene.pickUp( this, pos );
 		hero.sprite.showStatus( CharSprite.NEUTRAL, TXT_VALUE, quantity );
-		hero.spendAndNext( TIME_TO_PICK_UP );
+		hero.spendAndNext(getTIME_TO_PICK_UP());
 		
 		Sample.INSTANCE.play( Assets.Sounds.GOLD, 1, 1, Random.Float( 0.9f, 1.1f ) );
 		updateQuickslot();

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Honeypot.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Honeypot.java
@@ -45,7 +45,7 @@ public class Honeypot extends Item {
 	{
 		image = ItemSpriteSheet.HONEYPOT;
 
-		defaultAction = AC_THROW;
+		defaultAction = getAC_THROW();
 		usesTargeting = true;
 
 		stackable = true;

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Item.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Item.java
@@ -43,7 +43,6 @@ import com.shatteredpixel.shatteredpixeldungeon.scenes.CellSelector;
 import com.shatteredpixel.shatteredpixeldungeon.scenes.GameScene;
 import com.shatteredpixel.shatteredpixeldungeon.sprites.ItemSprite;
 import com.shatteredpixel.shatteredpixeldungeon.sprites.MissileSprite;
-import com.shatteredpixel.shatteredpixeldungeon.ui.InventoryPane;
 import com.shatteredpixel.shatteredpixeldungeon.ui.QuickSlotButton;
 import com.watabou.noosa.audio.Sample;
 import com.watabou.noosa.particles.Emitter;
@@ -58,15 +57,15 @@ import java.util.Comparator;
 
 public class Item implements Bundlable {
 
-	protected static final String TXT_TO_STRING_LVL		= "%s %+d";
-	protected static final String TXT_TO_STRING_X		= "%s x%d";
+	private static final String TXT_TO_STRING_LVL		= "%s %+d";
+	private static final String TXT_TO_STRING_X		= "%s x%d";
 	
-	protected static final float TIME_TO_THROW		= 1.0f;
-	protected static final float TIME_TO_PICK_UP	= 1.0f;
-	protected static final float TIME_TO_DROP		= 1.0f;
+	private static final float TIME_TO_THROW		= 1.0f;
+	private static final float TIME_TO_PICK_UP	= 1.0f;
+	private static final float TIME_TO_DROP		= 1.0f;
 	
-	public static final String AC_DROP		= "DROP";
-	public static final String AC_THROW		= "THROW";
+	private static final String AC_DROP		= "DROP";
+	private static final String AC_THROW		= "THROW";
 	
 	protected String defaultAction;
 	public boolean usesTargeting;
@@ -101,11 +100,39 @@ public class Item implements Bundlable {
 			return Generator.Category.order( lhs ) - Generator.Category.order( rhs );
 		}
 	};
-	
+
+	public static String getTXT_TO_STRING_LVL() {
+		return TXT_TO_STRING_LVL;
+	}
+
+	public static String getTXT_TO_STRING_X() {
+		return TXT_TO_STRING_X;
+	}
+
+	public static float getTIME_TO_THROW() {
+		return TIME_TO_THROW;
+	}
+
+	public static float getTIME_TO_PICK_UP() {
+		return TIME_TO_PICK_UP;
+	}
+
+	public static float getTIME_TO_DROP() {
+		return TIME_TO_DROP;
+	}
+
+	public static String getAC_DROP() {
+		return AC_DROP;
+	}
+
+	public static String getAC_THROW() {
+		return AC_THROW;
+	}
+
 	public ArrayList<String> actions( Hero hero ) {
 		ArrayList<String> actions = new ArrayList<>();
-		actions.add( AC_DROP );
-		actions.add( AC_THROW );
+		actions.add(getAC_DROP());
+		actions.add(getAC_THROW());
 		return actions;
 	}
 
@@ -122,7 +149,7 @@ public class Item implements Bundlable {
 			
 			GameScene.pickUp( this, pos );
 			Sample.INSTANCE.play( Assets.Sounds.ITEM );
-			hero.spendAndNext( TIME_TO_PICK_UP );
+			hero.spendAndNext(getTIME_TO_PICK_UP());
 			return true;
 			
 		} else {
@@ -131,7 +158,7 @@ public class Item implements Bundlable {
 	}
 	
 	public void doDrop( Hero hero ) {
-		hero.spendAndNext(TIME_TO_DROP);
+		hero.spendAndNext(getTIME_TO_DROP());
 		int pos = hero.pos;
 		Dungeon.level.drop(detachAll(hero.belongings.backpack), pos).sprite.drop(pos);
 	}
@@ -151,13 +178,13 @@ public class Item implements Bundlable {
 		curUser = hero;
 		curItem = this;
 		
-		if (action.equals( AC_DROP )) {
+		if (action.equals(getAC_DROP())) {
 			
 			if (hero.belongings.backpack.contains(this) || isEquipped(hero)) {
 				doDrop(hero);
 			}
 			
-		} else if (action.equals( AC_THROW )) {
+		} else if (action.equals(getAC_THROW())) {
 			
 			if (hero.belongings.backpack.contains(this) || isEquipped(hero)) {
 				doThrow(hero);
@@ -457,10 +484,10 @@ public class Item implements Bundlable {
 		String name = name();
 
 		if (visiblyUpgraded() != 0)
-			name = Messages.format( TXT_TO_STRING_LVL, name, visiblyUpgraded()  );
+			name = Messages.format(getTXT_TO_STRING_LVL(), name, visiblyUpgraded()  );
 
 		if (quantity > 1)
-			name = Messages.format( TXT_TO_STRING_X, name, quantity );
+			name = Messages.format(getTXT_TO_STRING_X(), name, quantity );
 
 		return name;
 
@@ -649,7 +676,7 @@ public class Item implements Bundlable {
 	}
 	
 	public float castDelay( Char user, int dst ){
-		return TIME_TO_THROW;
+		return getTIME_TO_THROW();
 	}
 	
 	protected static Hero curUser = null;

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/LostBackpack.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/LostBackpack.java
@@ -73,7 +73,7 @@ public class LostBackpack extends Item {
 
 		Item.updateQuickslot();
 		Sample.INSTANCE.play( Assets.Sounds.DEWDROP );
-		hero.spendAndNext(TIME_TO_PICK_UP);
+		hero.spendAndNext(getTIME_TO_PICK_UP());
 		GameScene.pickUp( this, pos );
 		((HeroSprite)hero.sprite).updateArmor();
 		return true;

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Recipe.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Recipe.java
@@ -26,6 +26,7 @@ import com.shatteredpixel.shatteredpixeldungeon.items.bombs.Bomb;
 import com.shatteredpixel.shatteredpixeldungeon.items.food.Blandfruit;
 import com.shatteredpixel.shatteredpixeldungeon.items.food.MeatPie;
 import com.shatteredpixel.shatteredpixeldungeon.items.food.StewedMeat;
+import com.shatteredpixel.shatteredpixeldungeon.items.food.StewedMeatEnum;
 import com.shatteredpixel.shatteredpixeldungeon.items.potions.AlchemicalCatalyst;
 import com.shatteredpixel.shatteredpixeldungeon.items.potions.Potion;
 import com.shatteredpixel.shatteredpixeldungeon.items.potions.brews.BlizzardBrew;
@@ -175,7 +176,7 @@ public abstract class Recipe {
 		new ExoticScroll.ScrollToExotic(),
 		new ArcaneResin.Recipe(),
 		new Alchemize.Recipe(),
-		new StewedMeat.oneMeat()
+		new StewedMeat.StewedMeatRecipe(StewedMeatEnum.STEWED_MEAT_ONE)
 	};
 	
 	private static Recipe[] twoIngredientRecipes = new Recipe[]{
@@ -205,12 +206,12 @@ public abstract class Recipe {
 		new WildEnergy.Recipe(),
 		new TelekineticGrab.Recipe(),
 		new SummonElemental.Recipe(),
-		new StewedMeat.twoMeat()
+		new StewedMeat.StewedMeatRecipe(StewedMeatEnum.STEWED_MEAT_TWO)
 	};
 	
 	private static Recipe[] threeIngredientRecipes = new Recipe[]{
 		new Potion.SeedToPotion(),
-		new StewedMeat.threeMeat(),
+		new StewedMeat.StewedMeatRecipe(StewedMeatEnum.STEWED_MEAT_THREE),
 		new MeatPie.Recipe()
 	};
 	

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/artifacts/DriedRose.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/artifacts/DriedRose.java
@@ -488,7 +488,7 @@ public class DriedRose extends Artifact {
 				return false;
 			} if ( rose.level() >= rose.levelCap ){
 				GLog.i( Messages.get(this, "no_room") );
-				hero.spendAndNext(TIME_TO_PICK_UP);
+				hero.spendAndNext(getTIME_TO_PICK_UP());
 				return true;
 			} else {
 
@@ -500,7 +500,7 @@ public class DriedRose extends Artifact {
 
 				Sample.INSTANCE.play( Assets.Sounds.DEWDROP );
 				GameScene.pickUp(this, pos);
-				hero.spendAndNext(TIME_TO_PICK_UP);
+				hero.spendAndNext(getTIME_TO_PICK_UP());
 				return true;
 
 			}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/artifacts/MasterThievesArmband.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/artifacts/MasterThievesArmband.java
@@ -39,17 +39,13 @@ import com.shatteredpixel.shatteredpixeldungeon.actors.mobs.npcs.Shopkeeper;
 import com.shatteredpixel.shatteredpixeldungeon.effects.Surprise;
 import com.shatteredpixel.shatteredpixeldungeon.items.Item;
 import com.shatteredpixel.shatteredpixeldungeon.items.rings.RingOfEnergy;
-import com.shatteredpixel.shatteredpixeldungeon.mechanics.Ballistica;
 import com.shatteredpixel.shatteredpixeldungeon.messages.Messages;
 import com.shatteredpixel.shatteredpixeldungeon.scenes.CellSelector;
 import com.shatteredpixel.shatteredpixeldungeon.scenes.GameScene;
 import com.shatteredpixel.shatteredpixeldungeon.sprites.ItemSpriteSheet;
-import com.shatteredpixel.shatteredpixeldungeon.utils.BArray;
 import com.shatteredpixel.shatteredpixeldungeon.utils.GLog;
 import com.watabou.noosa.audio.Sample;
-import com.watabou.utils.Bundle;
 import com.watabou.utils.Callback;
-import com.watabou.utils.PathFinder;
 import com.watabou.utils.Random;
 
 import java.util.ArrayList;
@@ -166,7 +162,7 @@ public class MasterThievesArmband extends Artifact {
 								} else {
 									if (loot.doPickUp(curUser)) {
 										//item collection happens instantly
-										curUser.spend(-TIME_TO_PICK_UP);
+										curUser.spend(-getTIME_TO_PICK_UP());
 									} else {
 										Dungeon.level.drop(loot, curUser.pos).sprite.drop();
 									}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/artifacts/TimekeepersHourglass.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/artifacts/TimekeepersHourglass.java
@@ -474,7 +474,7 @@ public class TimekeepersHourglass extends Artifact {
 				else
 					GLog.i( Messages.get(this, "levelup") );
 				GameScene.pickUp(this, pos);
-				hero.spendAndNext(TIME_TO_PICK_UP);
+				hero.spendAndNext(getTIME_TO_PICK_UP());
 				return true;
 			} else {
 				GLog.w( Messages.get(this, "no_hourglass") );

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/bombs/Bomb.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/bombs/Bomb.java
@@ -100,7 +100,7 @@ public class Bomb extends Item {
 
 		if (action.equals(AC_LIGHTTHROW)) {
 			lightingFuse = true;
-			action = AC_THROW;
+			action = getAC_THROW();
 		} else
 			lightingFuse = false;
 

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/food/Pasty.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/food/Pasty.java
@@ -24,22 +24,29 @@ package com.shatteredpixel.shatteredpixeldungeon.items.food;
 import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Hunger;
 
 public class Pasty extends Food {
-	//TODO: implement fun stuff for other holidays
-	//TODO: probably should externalize this if I want to add any more festive stuff.
-	protected static HolidayEnum holiday;
+    // TODO: implement fun stuff for other holidays
+    // TODO: probably should externalize this if I want to add any more festive stuff.
+
+    private static final Pasty pasty;
+    private static final HolidayEnum holiday;
+
     static {
         holiday = Holiday.getHoliday();
     }
 
-	{
-		reset();
+    static {
+        pasty = createInstanceInternal();
+    }
 
-		energy = Hunger.STARVING;
+    {
+        reset();
+        energy = Hunger. STARVING;
+        bones = true;
+    }
 
-		bones = true;
-	}
+    protected Pasty() {}
 
-    public static Pasty createInstance() { // singleton
+    private static Pasty createInstanceInternal() {
         switch (holiday) {
             case NONE:
                 return new PastyNONE();
@@ -50,5 +57,9 @@ public class Pasty extends Food {
             default:
                 throw new IllegalArgumentException("Invalid holiday value: " + holiday);
         }
+    }
+
+    public static Pasty createInstance() {
+        return pasty;
     }
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/food/StewedMeat.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/food/StewedMeat.java
@@ -26,54 +26,28 @@ import com.shatteredpixel.shatteredpixeldungeon.items.Recipe;
 import com.shatteredpixel.shatteredpixeldungeon.sprites.ItemSpriteSheet;
 
 public class StewedMeat extends Food {
-	
+
 	{
 		image = ItemSpriteSheet.STEWED;
 		energy = Hunger.HUNGRY/2f;
 	}
-	
+
 	@Override
 	public int value() {
 		return 8 * quantity;
 	}
-	
-	public static class oneMeat extends Recipe.SimpleRecipe{
-		{
-			inputs =  new Class[]{MysteryMeat.class};
-			inQuantity = new int[]{1};
-			
-			cost = 1;
-			
-			output = StewedMeat.class;
-			outQuantity = 1;
-		}
-	}
-	
-	public static class twoMeat extends Recipe.SimpleRecipe{
-		{
-			inputs =  new Class[]{MysteryMeat.class};
-			inQuantity = new int[]{2};
-			
-			cost = 2;
-			
-			output = StewedMeat.class;
-			outQuantity = 2;
-		}
-	}
-	
-	//red meat
-	//blue meat
-	
-	public static class threeMeat extends Recipe.SimpleRecipe{
-		{
-			inputs =  new Class[]{MysteryMeat.class};
-			inQuantity = new int[]{3};
-			
-			cost = 2;
-			
-			output = StewedMeat.class;
-			outQuantity = 3;
-		}
-	}
 
+	public static class StewedMeatRecipe extends Recipe.SimpleRecipe {
+		public StewedMeatRecipe(StewedMeatEnum quantity) {
+			int quantityIntValue = quantity.ordinal(); // Convert enum value to int
+
+			inputs = new Class[]{MysteryMeat.class};
+			inQuantity = new int[]{quantityIntValue};
+
+			cost = quantityIntValue;
+
+			output = StewedMeat.class;
+			outQuantity = quantityIntValue;
+		}
+	}
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/food/StewedMeatEnum.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/food/StewedMeatEnum.java
@@ -1,0 +1,20 @@
+package com.shatteredpixel.shatteredpixeldungeon.items.food;
+
+public enum StewedMeatEnum {
+    STEWED_MEAT_ONE(1),
+    STEWED_MEAT_TWO(2),
+    STEWED_MEAT_THREE(3);
+
+    private final int quantity;
+
+    StewedMeatEnum(int quantity) {
+        if (quantity < 1 || quantity > 3) {
+            throw new IllegalArgumentException("StewedMeat Quantity value must be between 1 and 3.");
+        }
+        this.quantity = quantity;
+    }
+
+    public int getQuantity() {
+        return quantity;
+    }
+}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/journal/DocumentPage.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/journal/DocumentPage.java
@@ -61,7 +61,7 @@ public abstract class DocumentPage extends Item {
 		}
 		document().findPage(page);
 		Sample.INSTANCE.play( Assets.Sounds.ITEM );
-		hero.spendAndNext( TIME_TO_PICK_UP );
+		hero.spendAndNext(getTIME_TO_PICK_UP());
 		return true;
 	}
 

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/journal/Guidebook.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/journal/Guidebook.java
@@ -54,7 +54,7 @@ public class Guidebook extends Item {
 		GLog.p(Messages.get(GameScene.class, "tutorial_guidebook"));
 		GameScene.flashForDocument(Document.ADVENTURERS_GUIDE, Document.GUIDE_INTRO);
 		Sample.INSTANCE.play( Assets.Sounds.ITEM );
-		hero.spendAndNext( TIME_TO_PICK_UP );
+		hero.spendAndNext(getTIME_TO_PICK_UP());
 		return true;
 	}
 

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/keys/Key.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/keys/Key.java
@@ -52,7 +52,7 @@ public abstract class Key extends Item {
 		WndJournal.last_index = 2;
 		Notes.add(this);
 		Sample.INSTANCE.play( Assets.Sounds.ITEM );
-		hero.spendAndNext( TIME_TO_PICK_UP );
+		hero.spendAndNext(getTIME_TO_PICK_UP());
 		GameScene.updateKeyDisplay();
 		return true;
 	}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/potions/Potion.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/potions/Potion.java
@@ -35,7 +35,6 @@ import com.shatteredpixel.shatteredpixeldungeon.items.Generator;
 import com.shatteredpixel.shatteredpixeldungeon.items.Item;
 import com.shatteredpixel.shatteredpixeldungeon.items.ItemStatusHandler;
 import com.shatteredpixel.shatteredpixeldungeon.items.Recipe;
-import com.shatteredpixel.shatteredpixeldungeon.items.bags.Bag;
 import com.shatteredpixel.shatteredpixeldungeon.items.potions.elixirs.ElixirOfHoneyedHealing;
 import com.shatteredpixel.shatteredpixeldungeon.items.potions.exotic.ExoticPotion;
 import com.shatteredpixel.shatteredpixeldungeon.items.potions.exotic.PotionOfCleansing;
@@ -197,7 +196,7 @@ public class Potion extends Item {
 	@Override
 	public String defaultAction() {
 		if (isKnown() && mustThrowPots.contains(this.getClass())) {
-			return AC_THROW;
+			return getAC_THROW();
 		} else if (isKnown() &&canThrowPots.contains(this.getClass())){
 			return AC_CHOOSE;
 		} else {

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/potions/brews/Brew.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/potions/brews/Brew.java
@@ -38,7 +38,7 @@ public abstract class Brew extends Potion {
 
 	@Override
 	public String defaultAction() {
-		return AC_THROW;
+		return getAC_THROW();
 	}
 	
 	@Override

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/quest/CeremonialCandle.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/quest/CeremonialCandle.java
@@ -52,7 +52,7 @@ public class CeremonialCandle extends Item {
 	{
 		image = ItemSpriteSheet.CANDLE;
 
-		defaultAction = AC_THROW;
+		defaultAction = getAC_THROW();
 
 		unique = true;
 		stackable = true;

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/spells/ReclaimTrap.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/spells/ReclaimTrap.java
@@ -27,7 +27,6 @@ import com.shatteredpixel.shatteredpixeldungeon.actors.hero.Hero;
 import com.shatteredpixel.shatteredpixeldungeon.items.quest.MetalShard;
 import com.shatteredpixel.shatteredpixeldungeon.items.scrolls.ScrollOfMagicMapping;
 import com.shatteredpixel.shatteredpixeldungeon.items.scrolls.ScrollOfRecharging;
-import com.shatteredpixel.shatteredpixeldungeon.levels.traps.SummoningTrap;
 import com.shatteredpixel.shatteredpixeldungeon.levels.traps.Trap;
 import com.shatteredpixel.shatteredpixeldungeon.mechanics.Ballistica;
 import com.shatteredpixel.shatteredpixeldungeon.messages.Messages;
@@ -53,8 +52,8 @@ public class ReclaimTrap extends TargetedSpell {
 		ArrayList<String> actions = super.actions(hero);
 		//prevents exploits
 		if (storedTrap != null){
-			actions.remove(AC_DROP);
-			actions.remove(AC_THROW);
+			actions.remove(getAC_DROP());
+			actions.remove(getAC_THROW());
 		}
 		return actions;
 	}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/spells/TelekineticGrab.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/spells/TelekineticGrab.java
@@ -73,7 +73,7 @@ public class TelekineticGrab extends TargetedSpell {
 				Item item = ch.buff(PinCushion.class).grabOne();
 
 				if (item.doPickUp(hero, ch.pos)) {
-					hero.spend(-Item.TIME_TO_PICK_UP); //casting the spell already takes a turn
+					hero.spend(-Item.getTIME_TO_PICK_UP()); //casting the spell already takes a turn
 					GLog.i( Messages.capitalize(Messages.get(hero, "you_now_have", item.name())) );
 
 				} else {
@@ -98,7 +98,7 @@ public class TelekineticGrab extends TargetedSpell {
 				Item item = h.peek();
 				if (item.doPickUp(hero, h.pos)) {
 					h.pickUp();
-					hero.spend(-Item.TIME_TO_PICK_UP); //casting the spell already takes a turn
+					hero.spend(-Item.getTIME_TO_PICK_UP()); //casting the spell already takes a turn
 					GLog.i( Messages.capitalize(Messages.get(hero, "you_now_have", item.name())) );
 
 				} else {

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/stones/Runestone.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/stones/Runestone.java
@@ -30,7 +30,7 @@ public abstract class Runestone extends Item {
 	
 	{
 		stackable = true;
-		defaultAction = AC_THROW;
+		defaultAction = getAC_THROW();
 	}
 
 	//runestones press the cell they're thrown to by default, but a couple stones override this
@@ -38,7 +38,7 @@ public abstract class Runestone extends Item {
 
 	@Override
 	protected void onThrow(int cell) {
-		if (Dungeon.level.pit[cell] || !defaultAction().equals(AC_THROW)){
+		if (Dungeon.level.pit[cell] || !defaultAction().equals(getAC_THROW())){
 			super.onThrow( cell );
 		} else {
 			if (pressesCell) Dungeon.level.pressCell( cell );

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/weapon/missiles/HeavyBoomerang.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/weapon/missiles/HeavyBoomerang.java
@@ -27,7 +27,6 @@ import com.shatteredpixel.shatteredpixeldungeon.actors.Actor;
 import com.shatteredpixel.shatteredpixeldungeon.actors.Char;
 import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Buff;
 import com.shatteredpixel.shatteredpixeldungeon.actors.hero.Hero;
-import com.shatteredpixel.shatteredpixeldungeon.actors.hero.Talent;
 import com.shatteredpixel.shatteredpixeldungeon.sprites.ItemSpriteSheet;
 import com.shatteredpixel.shatteredpixeldungeon.sprites.MissileSprite;
 import com.watabou.noosa.tweeners.AlphaTweener;
@@ -127,7 +126,7 @@ public class HeavyBoomerang extends MissileWeapon {
 											if (returnTarget == target){
 												if (target instanceof Hero && boomerang.doPickUp((Hero) target)) {
 													//grabbing the boomerang takes no time
-													((Hero) target).spend(-TIME_TO_PICK_UP);
+													((Hero) target).spend(-getTIME_TO_PICK_UP());
 												} else {
 													Dungeon.level.drop(boomerang, returnPos).sprite.drop();
 												}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/weapon/missiles/MissileWeapon.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/weapon/missiles/MissileWeapon.java
@@ -35,12 +35,10 @@ import com.shatteredpixel.shatteredpixeldungeon.actors.hero.Talent;
 import com.shatteredpixel.shatteredpixeldungeon.items.Item;
 import com.shatteredpixel.shatteredpixeldungeon.items.bags.Bag;
 import com.shatteredpixel.shatteredpixeldungeon.items.bags.MagicalHolster;
-import com.shatteredpixel.shatteredpixeldungeon.items.rings.RingOfArcana;
 import com.shatteredpixel.shatteredpixeldungeon.items.rings.RingOfSharpshooting;
 import com.shatteredpixel.shatteredpixeldungeon.items.weapon.SpiritBow;
 import com.shatteredpixel.shatteredpixeldungeon.items.weapon.Weapon;
 import com.shatteredpixel.shatteredpixeldungeon.items.weapon.enchantments.Projecting;
-import com.shatteredpixel.shatteredpixeldungeon.items.weapon.melee.Scimitar;
 import com.shatteredpixel.shatteredpixeldungeon.items.weapon.missiles.darts.Dart;
 import com.shatteredpixel.shatteredpixeldungeon.messages.Messages;
 import com.shatteredpixel.shatteredpixeldungeon.sprites.ItemSpriteSheet;
@@ -58,7 +56,7 @@ abstract public class MissileWeapon extends Weapon {
 		
 		bones = true;
 
-		defaultAction = AC_THROW;
+		defaultAction = getAC_THROW();
 		usesTargeting = true;
 	}
 	

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/plants/Plant.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/plants/Plant.java
@@ -132,7 +132,7 @@ public abstract class Plant implements Bundlable {
 		
 		{
 			stackable = true;
-			defaultAction = AC_THROW;
+			defaultAction = getAC_THROW();
 		}
 		
 		protected Class<? extends Plant> plantClass;

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/ui/QuickRecipe.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/ui/QuickRecipe.java
@@ -29,12 +29,7 @@ import com.shatteredpixel.shatteredpixeldungeon.items.Item;
 import com.shatteredpixel.shatteredpixeldungeon.items.LiquidMetal;
 import com.shatteredpixel.shatteredpixeldungeon.items.Recipe;
 import com.shatteredpixel.shatteredpixeldungeon.items.bombs.Bomb;
-import com.shatteredpixel.shatteredpixeldungeon.items.food.Blandfruit;
-import com.shatteredpixel.shatteredpixeldungeon.items.food.Food;
-import com.shatteredpixel.shatteredpixeldungeon.items.food.MeatPie;
-import com.shatteredpixel.shatteredpixeldungeon.items.food.MysteryMeat;
-import com.shatteredpixel.shatteredpixeldungeon.items.food.Pasty;
-import com.shatteredpixel.shatteredpixeldungeon.items.food.StewedMeat;
+import com.shatteredpixel.shatteredpixeldungeon.items.food.*;
 import com.shatteredpixel.shatteredpixeldungeon.items.potions.AlchemicalCatalyst;
 import com.shatteredpixel.shatteredpixeldungeon.items.potions.Potion;
 import com.shatteredpixel.shatteredpixeldungeon.items.potions.brews.BlizzardBrew;
@@ -284,9 +279,9 @@ public class QuickRecipe extends Component {
 				}
 				return result;
 			case 2:
-				result.add(new QuickRecipe( new StewedMeat.oneMeat() ));
-				result.add(new QuickRecipe( new StewedMeat.twoMeat() ));
-				result.add(new QuickRecipe( new StewedMeat.threeMeat() ));
+				result.add(new QuickRecipe( new StewedMeat.StewedMeatRecipe(StewedMeatEnum.STEWED_MEAT_ONE) ));
+				result.add(new QuickRecipe( new StewedMeat.StewedMeatRecipe(StewedMeatEnum.STEWED_MEAT_TWO) ));
+				result.add(new QuickRecipe( new StewedMeat.StewedMeatRecipe(StewedMeatEnum.STEWED_MEAT_THREE) ));
 				result.add(null);
 				result.add(new QuickRecipe( new MeatPie.Recipe(),
 						new ArrayList<Item>(Arrays.asList(Pasty.createInstance(), new Food(), new MysteryMeat.PlaceHolder())),


### PR DESCRIPTION
# Items/Item.java_신다윗
Date: 2023.05.26~2023.05.27
Manager: 신다윗
Status: Done
Writer: 신다윗
Work Type: Encapsulate Field for immutable Fields: Encapsulation, Maintainability
# Commit Message
Encapsulate Field for immutable Fields: Encapsulation, Maintainability
# 패턴에 대한 설명
Encapsulate Field for immutable Fields: Encapsulation, Maintainability
- Item.java
- A bunch of classes related to immutable Fields of Item.java
# 수행 이유
I tried to distinguish between mutable and immutable fields in the field of item class and separate field class and method class. However, it failed in the process of refactoring the mutable field.
So, only immutable fields were refactored into getter methods.
# Effect
can enforce encapsulation and maintain the principle of data hiding
# 수행 대상
Items/Item.java
# 전/후 Diagram
생략
# reference  
[Encapsulate Field](https://refactoring.guru/ko/encapsulate-field)