### PR TITLE
4주차_buffs_정진규_ 수정

### DIFF
--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/Actor.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/Actor.java
@@ -25,7 +25,6 @@ import com.shatteredpixel.shatteredpixeldungeon.Dungeon;
 import com.shatteredpixel.shatteredpixeldungeon.Statistics;
 import com.shatteredpixel.shatteredpixeldungeon.actors.blobs.Blob;
 import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Buff;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Buff_collection;
 import com.shatteredpixel.shatteredpixeldungeon.actors.mobs.Mob;
 import com.watabou.utils.Bundlable;
 import com.watabou.utils.Bundle;
@@ -53,10 +52,6 @@ public abstract class Actor implements Bundlable {
 
 	//used to determine what order actors act in if their time is equal. Higher values act earlier.
 	protected int actPriority = DEFAULT;
-	protected Buff_collection buff_collection_init;
-	{
-		buff_collection_init = new Buff_collection();
-	}
 
 	protected abstract boolean act();
 

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/Char.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/Char.java
@@ -815,12 +815,15 @@ public abstract class Char extends Actor {
 		return false;
 	}
 
+	public synchronized boolean add(Buff buff){
+		return add(Build_buff_collection.to_colleciton(buff));
+	}
 	public synchronized boolean add(Buff_Observer buff ) {
 
 		if (buff(PotionOfCleansing.Cleanse.class) != null) { //cleansing buff
 			if (buff.get().type == NEGATIVE
-					&& !(buff instanceof AllyBuff)
-					&& !(buff instanceof LostInventory)){
+					&& !(buff.get() instanceof AllyBuff)
+					&& !(buff.get() instanceof LostInventory)){
 				return false;
 			}
 		}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/Char.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/Char.java
@@ -80,6 +80,9 @@ import com.watabou.utils.Random;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.stream.Collectors;
+
+import static com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Buff.buffType.NEGATIVE;
 
 public abstract class Char extends Actor {
 	
@@ -111,7 +114,7 @@ public abstract class Char extends Actor {
 	public boolean[] fieldOfView = null;
 	
 //	private LinkedHashSet<Buff> buffs = new LinkedHashSet<>();
-	private Buff_Observer buff_collection = buff_collection_init;
+	private LinkedHashSet<Buff_Observer> buff_collection = new LinkedHashSet<>();
 
 	@Override
 	protected boolean act() {
@@ -245,8 +248,8 @@ public abstract class Char extends Actor {
 		bundle.put( POS, pos );
 		bundle.put( TAG_HP, HP );
 		bundle.put( TAG_HT, HT );
-//		bundle.put( BUFFS, buffs );
-		buff_collection.put(BUFFS, bundle);
+//		buff_collection.put(BUFFS, bundle);
+		bundle.put( BUFFS, (Bundlable) buff_collection);
 
 	}
 	
@@ -771,17 +774,19 @@ public abstract class Char extends Actor {
 		super.spend( time / timeScale );
 	}
 	
+	@SuppressWarnings("NewApi")
 	public synchronized LinkedHashSet<Buff> buffs() {
-		return buff_collection.get();
+		return buff_collection.stream().map(buff -> buff.get()).collect(Collectors.toCollection(LinkedHashSet::new));
 	}
 	
 	@SuppressWarnings("unchecked")
 	//returns all buffs assignable from the given buff class
 	public synchronized <T extends Buff> HashSet<T> buffs( Class<T> c ) {
 		HashSet<T> filtered = new HashSet<>();
-		for (Buff b : buff_collection.get()) {
-			if (c.isInstance( b )) {
-				filtered.add( (T)b );
+		for (Buff_Observer b : buff_collection) {
+			Buff temp = b.get();
+			if (c.isInstance( temp )) {
+				filtered.add( (T)temp );
 			}
 		}
 		return filtered;
@@ -790,9 +795,10 @@ public abstract class Char extends Actor {
 	@SuppressWarnings("unchecked")
 	//returns an instance of the specific buff class, if it exists. Not just assignable
 	public synchronized  <T extends Buff> T buff( Class<T> c ) {
-		for (Buff b : buff_collection.get()) {
-			if (b.getClass() == c) {
-				return (T)b;
+		for (Buff_Observer b : buff_collection) {
+			Buff temp = b.get();
+			if (temp.getClass() == c) {
+				return (T)temp;
 			}
 		}
 		return null;
@@ -800,18 +806,19 @@ public abstract class Char extends Actor {
 
 	public synchronized boolean isCharmedBy( Char ch ) {
 		int chID = ch.id();
-		for (Buff b : buff_collection.get()) {
-			if (b instanceof Charm && ((Charm)b).object == chID) {
+		for (Buff_Observer b : buff_collection) {
+			Buff temp = b.get();
+			if (temp instanceof Charm && ((Charm)temp).object == chID) {
 				return true;
 			}
 		}
 		return false;
 	}
 
-	public synchronized boolean add( Buff buff ) {
+	public synchronized boolean add(Buff_Observer buff ) {
 
 		if (buff(PotionOfCleansing.Cleanse.class) != null) { //cleansing buff
-			if (buff.type == Buff.buffType.NEGATIVE
+			if (buff.get().type == NEGATIVE
 					&& !(buff instanceof AllyBuff)
 					&& !(buff instanceof LostInventory)){
 				return false;
@@ -823,19 +830,19 @@ public abstract class Char extends Actor {
 		}
 
 		buff_collection.add( buff );
-		if (Actor.chars().contains(this)) Actor.add( buff );
+		if (Actor.chars().contains(this)) Actor.add( buff.get());
 
-		if (sprite != null && buff.announced) {
-			switch (buff.type) {
+		if (sprite != null && buff.get().announced) {
+			switch (buff.get().type) {
 				case POSITIVE:
-					sprite.showStatus(CharSprite.POSITIVE, Messages.titleCase(buff.name()));
+					sprite.showStatus(CharSprite.POSITIVE, Messages.titleCase(buff.get().name()));
 					break;
 				case NEGATIVE:
-					sprite.showStatus(CharSprite.NEGATIVE, Messages.titleCase(buff.name()));
+					sprite.showStatus(CharSprite.NEGATIVE, Messages.titleCase(buff.get().name()));
 					break;
 				case NEUTRAL:
 				default:
-					sprite.showStatus(CharSprite.NEUTRAL, Messages.titleCase(buff.name()));
+					sprite.showStatus(CharSprite.NEUTRAL, Messages.titleCase(buff.get().name()));
 					break;
 			}
 		}
@@ -859,14 +866,15 @@ public abstract class Char extends Actor {
 		}
 	}
 	
+	@SuppressWarnings("NewApi")
 	@Override
 	protected synchronized void onRemove() {
-		buff_collection.detach();
+		buff_collection.stream().forEach(buff -> buff.get().detach());
 	}
 	
 	public synchronized void updateSpriteState() {
-		for (Buff buff:buff_collection.get()) {
-			buff.fx( true );
+		for (Buff_Observer buff:buff_collection) {
+			buff.get().fx( true );
 		}
 	}
 	

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/buffs/Buff_Observer.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/buffs/Buff_Observer.java
@@ -1,14 +1,7 @@
 package com.shatteredpixel.shatteredpixeldungeon.actors.buffs;
 
-import com.watabou.utils.Bundle;
-
-import java.util.LinkedHashSet;
-
 public interface Buff_Observer {
-    public abstract void put(String key, Bundle bundle);
-    public abstract LinkedHashSet<Buff> get();
-    public abstract void add(Buff buff);
-    public abstract void remove(Buff buff);
+    public abstract Buff get();
     public abstract void detach();
 
 

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/buffs/Buff_collection.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/buffs/Buff_collection.java
@@ -5,6 +5,7 @@ import com.watabou.utils.Bundle;
 import java.util.LinkedHashSet;
 import java.util.stream.Collectors;
 
+
 public class Buff_collection implements Buff_Observer{
     private LinkedHashSet<Buff> buffs = new LinkedHashSet<>();
 
@@ -27,6 +28,8 @@ public class Buff_collection implements Buff_Observer{
     public void remove(Buff buff){
         buffs.remove(buff);
     }
+
+    @SuppressWarnings("NewApi")
     @Override
     public void detach(){
         buffs.stream().collect(Collectors.toList()).forEach(buff -> {buff.detach();});

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/buffs/Buff_collection.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/buffs/Buff_collection.java
@@ -5,7 +5,7 @@ import com.watabou.utils.Bundle;
 
 
 public class Buff_collection implements Buff_Observer, Bundlable {
-    private Buff buff;
+    private final Buff buff;
     public Buff_collection(Buff buff) {
         this.buff = buff;
     }
@@ -21,6 +21,7 @@ public class Buff_collection implements Buff_Observer, Bundlable {
     public void detach(){
         buff.detach();
     }
+
 
     @Override
     public void restoreFromBundle(Bundle bundle) {

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/buffs/Buff_collection.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/buffs/Buff_collection.java
@@ -1,38 +1,34 @@
 package com.shatteredpixel.shatteredpixeldungeon.actors.buffs;
 
+import com.watabou.utils.Bundlable;
 import com.watabou.utils.Bundle;
 
-import java.util.LinkedHashSet;
-import java.util.stream.Collectors;
 
-
-public class Buff_collection implements Buff_Observer{
-    private LinkedHashSet<Buff> buffs = new LinkedHashSet<>();
-
-
-    @Override
-    public void put(String key, Bundle bundle){
-        bundle.put(key,buffs);
+public class Buff_collection implements Buff_Observer, Bundlable {
+    private Buff buff;
+    public Buff_collection(Buff buff) {
+        this.buff = buff;
     }
 
     @Override
-    public LinkedHashSet<Buff> get(){
-        return new LinkedHashSet<>(buffs);
+    public Buff get(){
+        return buff;
     }
 
-    @Override
-    public void add(Buff buff){
-        buffs.add(buff);
-    }
-    @Override
-    public void remove(Buff buff){
-        buffs.remove(buff);
-    }
 
     @SuppressWarnings("NewApi")
     @Override
     public void detach(){
-        buffs.stream().collect(Collectors.toList()).forEach(buff -> {buff.detach();});
+        buff.detach();
     }
 
+    @Override
+    public void restoreFromBundle(Bundle bundle) {
+        buff.restoreFromBundle(bundle);
+    }
+
+    @Override
+    public void storeInBundle(Bundle bundle) {
+        buff.storeInBundle(bundle);
+    }
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/buffs/Build_buff_collection.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/buffs/Build_buff_collection.java
@@ -1,0 +1,7 @@
+package com.shatteredpixel.shatteredpixeldungeon.actors.buffs;
+
+public interface Build_buff_collection {
+    static Buff_Observer to_colleciton(Buff buff){ //
+        return new Buff_collection(buff);
+    }
+}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/hero/Hero.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/hero/Hero.java
@@ -32,35 +32,7 @@ import com.shatteredpixel.shatteredpixeldungeon.Statistics;
 import com.shatteredpixel.shatteredpixeldungeon.actors.Actor;
 import com.shatteredpixel.shatteredpixeldungeon.actors.Char;
 import com.shatteredpixel.shatteredpixeldungeon.actors.blobs.SacrificialFire;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.AdrenalineSurge;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Amok;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.AnkhInvulnerability;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.ArtifactRecharge;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.AscensionChallenge;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Awareness;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Barkskin;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Barrier;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Berserk;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Bless;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Buff;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Burning;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Combo;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Drowsy;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Foresight;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.HoldFast;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Hunger;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Invisibility;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Levitation;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.LostInventory;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.MindVision;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Momentum;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.MonkEnergy;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Paralysis;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.PhysicalEmpower;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Recharging;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Regeneration;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.SnipersMark;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Vertigo;
+import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.*;
 import com.shatteredpixel.shatteredpixeldungeon.actors.hero.abilities.ArmorAbility;
 import com.shatteredpixel.shatteredpixeldungeon.actors.hero.abilities.duelist.Challenge;
 import com.shatteredpixel.shatteredpixeldungeon.actors.hero.abilities.duelist.ElementalStrike;
@@ -1769,13 +1741,12 @@ public class Hero extends Char {
 	}
 	
 	@Override
-	public boolean add( Buff buff ) {
+	public boolean add( Buff_Observer buff ) {
 
 		if (buff(TimekeepersHourglass.timeStasis.class) != null) {
 			return false;
 		}
-
-		boolean added = super.add( buff );
+		boolean added = super.add(buff);
 
 		if (sprite != null && added) {
 			String msg = Messages.get(buff,"heromsg").isEmpty() ? null : Messages.get(buff,"heromsg");

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/hero/abilities/duelist/Feint.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/hero/abilities/duelist/Feint.java
@@ -25,11 +25,7 @@ import com.shatteredpixel.shatteredpixeldungeon.Assets;
 import com.shatteredpixel.shatteredpixeldungeon.Dungeon;
 import com.shatteredpixel.shatteredpixeldungeon.actors.Actor;
 import com.shatteredpixel.shatteredpixeldungeon.actors.Char;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.BlobImmunity;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Buff;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.FlavourBuff;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Haste;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Vulnerable;
+import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.*;
 import com.shatteredpixel.shatteredpixeldungeon.actors.hero.Hero;
 import com.shatteredpixel.shatteredpixeldungeon.actors.hero.Talent;
 import com.shatteredpixel.shatteredpixeldungeon.actors.hero.abilities.ArmorAbility;
@@ -195,7 +191,7 @@ public class Feint extends ArmorAbility {
 		}
 
 		@Override
-		public boolean add( Buff buff ) {
+		public boolean add(Buff_Observer buff ) {
 			return false;
 		}
 

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/Bee.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/Bee.java
@@ -26,7 +26,7 @@ import com.shatteredpixel.shatteredpixeldungeon.actors.Actor;
 import com.shatteredpixel.shatteredpixeldungeon.actors.Char;
 import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.AllyBuff;
 import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Amok;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Buff;
+import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Buff_Observer;
 import com.shatteredpixel.shatteredpixeldungeon.messages.Messages;
 import com.shatteredpixel.shatteredpixeldungeon.sprites.BeeSprite;
 import com.watabou.utils.Bundle;
@@ -124,7 +124,7 @@ public class Bee extends Mob {
 	}
 
 	@Override
-	public boolean add(Buff buff) {
+	public boolean add(Buff_Observer buff) {
 		if (super.add(buff)) {
 			//TODO maybe handle honeyed bees with their own ally buff?
 			if (buff instanceof AllyBuff) {

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/Elemental.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/Elemental.java
@@ -26,11 +26,7 @@ import com.shatteredpixel.shatteredpixeldungeon.Dungeon;
 import com.shatteredpixel.shatteredpixeldungeon.Statistics;
 import com.shatteredpixel.shatteredpixeldungeon.actors.Char;
 import com.shatteredpixel.shatteredpixeldungeon.actors.blobs.Freezing;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Blindness;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Buff;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Burning;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Chill;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Invisibility;
+import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.*;
 import com.shatteredpixel.shatteredpixeldungeon.effects.Lightning;
 import com.shatteredpixel.shatteredpixeldungeon.effects.Splash;
 import com.shatteredpixel.shatteredpixeldungeon.items.potions.PotionOfFrost;
@@ -169,7 +165,7 @@ public abstract class Elemental extends Mob {
 	}
 	
 	@Override
-	public boolean add( Buff buff ) {
+	public boolean add(Buff_Observer buff ) {
 		if (harmfulBuffs.contains( buff.getClass() )) {
 			damage( Random.NormalIntRange( HT/2, HT * 3/5 ), buff );
 			return false;

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/Mimic.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/Mimic.java
@@ -27,6 +27,7 @@ import com.shatteredpixel.shatteredpixeldungeon.Dungeon;
 import com.shatteredpixel.shatteredpixeldungeon.actors.Actor;
 import com.shatteredpixel.shatteredpixeldungeon.actors.Char;
 import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Buff;
+import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Buff_Observer;
 import com.shatteredpixel.shatteredpixeldungeon.effects.CellEmitter;
 import com.shatteredpixel.shatteredpixeldungeon.effects.Speck;
 import com.shatteredpixel.shatteredpixeldungeon.items.Generator;
@@ -91,9 +92,9 @@ public class Mimic extends Mob {
 	}
 
 	@Override
-	public boolean add(Buff buff) {
+	public boolean add(Buff_Observer buff) {
 		if (super.add(buff)) {
-			if (buff.type == Buff.buffType.NEGATIVE && alignment == Alignment.NEUTRAL) {
+			if (buff.get().type == Buff.buffType.NEGATIVE && alignment == Alignment.NEUTRAL) {
 				alignment = Alignment.ENEMY;
 				stopHiding();
 				if (sprite != null) sprite.idle();

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/Mob.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/Mob.java
@@ -28,24 +28,7 @@ import com.shatteredpixel.shatteredpixeldungeon.Dungeon;
 import com.shatteredpixel.shatteredpixeldungeon.Statistics;
 import com.shatteredpixel.shatteredpixeldungeon.actors.Actor;
 import com.shatteredpixel.shatteredpixeldungeon.actors.Char;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Adrenaline;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.AllyBuff;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Amok;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.AscensionChallenge;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Buff;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.ChampionEnemy;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Charm;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Corruption;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Dread;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Haste;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Hunger;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Invisibility;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.MindVision;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.MonkEnergy;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Preparation;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Sleep;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.SoulMark;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Terror;
+import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.*;
 import com.shatteredpixel.shatteredpixeldungeon.actors.hero.Hero;
 import com.shatteredpixel.shatteredpixeldungeon.actors.hero.HeroClass;
 import com.shatteredpixel.shatteredpixeldungeon.actors.hero.HeroSubClass;
@@ -58,18 +41,15 @@ import com.shatteredpixel.shatteredpixeldungeon.effects.Surprise;
 import com.shatteredpixel.shatteredpixeldungeon.effects.Wound;
 import com.shatteredpixel.shatteredpixeldungeon.effects.particles.ShadowParticle;
 import com.shatteredpixel.shatteredpixeldungeon.items.Generator;
-import com.shatteredpixel.shatteredpixeldungeon.items.Gold;
 import com.shatteredpixel.shatteredpixeldungeon.items.Item;
 import com.shatteredpixel.shatteredpixeldungeon.items.artifacts.MasterThievesArmband;
 import com.shatteredpixel.shatteredpixeldungeon.items.artifacts.TimekeepersHourglass;
 import com.shatteredpixel.shatteredpixeldungeon.items.rings.Ring;
 import com.shatteredpixel.shatteredpixeldungeon.items.rings.RingOfWealth;
 import com.shatteredpixel.shatteredpixeldungeon.items.stones.StoneOfAggression;
-import com.shatteredpixel.shatteredpixeldungeon.items.wands.Wand;
 import com.shatteredpixel.shatteredpixeldungeon.items.weapon.SpiritBow;
 import com.shatteredpixel.shatteredpixeldungeon.items.weapon.Weapon;
 import com.shatteredpixel.shatteredpixeldungeon.items.weapon.enchantments.Lucky;
-import com.shatteredpixel.shatteredpixeldungeon.items.weapon.melee.MeleeWeapon;
 import com.shatteredpixel.shatteredpixeldungeon.items.weapon.missiles.MissileWeapon;
 import com.shatteredpixel.shatteredpixeldungeon.items.weapon.missiles.darts.Dart;
 import com.shatteredpixel.shatteredpixeldungeon.levels.Level;
@@ -395,7 +375,7 @@ public abstract class Mob extends Char {
 	}
 	
 	@Override
-	public boolean add( Buff buff ) {
+	public boolean add(Buff_Observer buff ) {
 		if (super.add( buff )) {
 			if (buff instanceof Amok || buff instanceof AllyBuff) {
 				state = HUNTING;

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/Pylon.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/Pylon.java
@@ -28,18 +28,10 @@ import com.shatteredpixel.shatteredpixeldungeon.Statistics;
 import com.shatteredpixel.shatteredpixeldungeon.actors.Actor;
 import com.shatteredpixel.shatteredpixeldungeon.actors.Char;
 import com.shatteredpixel.shatteredpixeldungeon.actors.blobs.Electricity;
-import com.shatteredpixel.shatteredpixeldungeon.actors.blobs.ToxicGas;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Amok;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Buff;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Dread;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Paralysis;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Sleep;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Terror;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Vertigo;
+import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.*;
 import com.shatteredpixel.shatteredpixeldungeon.effects.CellEmitter;
 import com.shatteredpixel.shatteredpixeldungeon.effects.Lightning;
 import com.shatteredpixel.shatteredpixeldungeon.effects.particles.SparkParticle;
-import com.shatteredpixel.shatteredpixeldungeon.items.Heap;
 import com.shatteredpixel.shatteredpixeldungeon.levels.CavesBossLevel;
 import com.shatteredpixel.shatteredpixeldungeon.messages.Messages;
 import com.shatteredpixel.shatteredpixeldungeon.sprites.CharSprite;
@@ -169,7 +161,7 @@ public class Pylon extends Mob {
 	}
 
 	@Override
-	public boolean add(Buff buff) {
+	public boolean add(Buff_Observer buff) {
 		//immune to all buffs/debuffs when inactive
 		if (alignment != Alignment.NEUTRAL) {
 			return super.add(buff);

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/Statue.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/Statue.java
@@ -24,6 +24,7 @@ package com.shatteredpixel.shatteredpixeldungeon.actors.mobs;
 import com.shatteredpixel.shatteredpixeldungeon.Dungeon;
 import com.shatteredpixel.shatteredpixeldungeon.actors.Char;
 import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Buff;
+import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Buff_Observer;
 import com.shatteredpixel.shatteredpixeldungeon.items.Generator;
 import com.shatteredpixel.shatteredpixeldungeon.items.weapon.Weapon;
 import com.shatteredpixel.shatteredpixeldungeon.items.weapon.Weapon.Enchantment;
@@ -112,9 +113,9 @@ public class Statue extends Mob {
 	}
 	
 	@Override
-	public boolean add(Buff buff) {
+	public boolean add(Buff_Observer buff) {
 		if (super.add(buff)) {
-			if (state == PASSIVE && buff.type == Buff.buffType.NEGATIVE) {
+			if (state == PASSIVE && buff.get().type == Buff.buffType.NEGATIVE) {
 				state = HUNTING;
 			}
 			return true;

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/Tengu.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/Tengu.java
@@ -31,13 +31,7 @@ import com.shatteredpixel.shatteredpixeldungeon.actors.Char;
 import com.shatteredpixel.shatteredpixeldungeon.actors.blobs.Blob;
 import com.shatteredpixel.shatteredpixeldungeon.actors.blobs.Electricity;
 import com.shatteredpixel.shatteredpixeldungeon.actors.blobs.Fire;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Blindness;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Buff;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Burning;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Doom;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Dread;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.LockedFloor;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Terror;
+import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.*;
 import com.shatteredpixel.shatteredpixeldungeon.actors.hero.Hero;
 import com.shatteredpixel.shatteredpixeldungeon.actors.hero.HeroSubClass;
 import com.shatteredpixel.shatteredpixeldungeon.effects.BlobEmitter;
@@ -121,7 +115,7 @@ public class Tengu extends Mob {
 
 	//Tengu is immune to debuffs and damage when removed from the level
 	@Override
-	public boolean add(Buff buff) {
+	public boolean add(Buff_Observer buff) {
 		if (Actor.chars().contains(this) || buff instanceof Doom || loading){
 			return super.add(buff);
 		}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/npcs/Blacksmith.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/npcs/Blacksmith.java
@@ -27,7 +27,7 @@ import com.shatteredpixel.shatteredpixeldungeon.Dungeon;
 import com.shatteredpixel.shatteredpixeldungeon.Statistics;
 import com.shatteredpixel.shatteredpixeldungeon.actors.Char;
 import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.AscensionChallenge;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Buff;
+import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Buff_Observer;
 import com.shatteredpixel.shatteredpixeldungeon.items.BrokenSeal;
 import com.shatteredpixel.shatteredpixeldungeon.items.EquipableItem;
 import com.shatteredpixel.shatteredpixeldungeon.items.Item;
@@ -268,7 +268,7 @@ public class Blacksmith extends NPC {
 	}
 
 	@Override
-	public boolean add( Buff buff ) {
+	public boolean add(Buff_Observer buff ) {
 		return false;
 	}
 	

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/npcs/Ghost.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/npcs/Ghost.java
@@ -26,7 +26,7 @@ import com.shatteredpixel.shatteredpixeldungeon.Dungeon;
 import com.shatteredpixel.shatteredpixeldungeon.Statistics;
 import com.shatteredpixel.shatteredpixeldungeon.actors.Char;
 import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.AscensionChallenge;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Buff;
+import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Buff_Observer;
 import com.shatteredpixel.shatteredpixeldungeon.actors.mobs.FetidRat;
 import com.shatteredpixel.shatteredpixeldungeon.actors.mobs.GnollTrickster;
 import com.shatteredpixel.shatteredpixeldungeon.actors.mobs.GreatCrab;
@@ -102,7 +102,7 @@ public class Ghost extends NPC {
 	}
 
 	@Override
-	public boolean add( Buff buff ) {
+	public boolean add(Buff_Observer buff ) {
 		return false;
 	}
 	

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/npcs/Imp.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/npcs/Imp.java
@@ -25,7 +25,7 @@ import com.shatteredpixel.shatteredpixeldungeon.Dungeon;
 import com.shatteredpixel.shatteredpixeldungeon.Statistics;
 import com.shatteredpixel.shatteredpixeldungeon.actors.Char;
 import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.AscensionChallenge;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Buff;
+import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Buff_Observer;
 import com.shatteredpixel.shatteredpixeldungeon.actors.mobs.Golem;
 import com.shatteredpixel.shatteredpixeldungeon.actors.mobs.Mob;
 import com.shatteredpixel.shatteredpixeldungeon.actors.mobs.Monk;
@@ -85,7 +85,7 @@ public class Imp extends NPC {
 	}
 
 	@Override
-	public boolean add( Buff buff ) {
+	public boolean add(Buff_Observer buff ) {
 		return false;
 	}
 	

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/npcs/RatKing.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/npcs/RatKing.java
@@ -24,7 +24,7 @@ package com.shatteredpixel.shatteredpixeldungeon.actors.mobs.npcs;
 import com.shatteredpixel.shatteredpixeldungeon.Badges;
 import com.shatteredpixel.shatteredpixeldungeon.Dungeon;
 import com.shatteredpixel.shatteredpixeldungeon.actors.Char;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Buff;
+import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Buff_Observer;
 import com.shatteredpixel.shatteredpixeldungeon.actors.hero.abilities.Ratmogrify;
 import com.shatteredpixel.shatteredpixeldungeon.items.KingsCrown;
 import com.shatteredpixel.shatteredpixeldungeon.messages.Messages;
@@ -64,7 +64,7 @@ public class RatKing extends NPC {
 	}
 
 	@Override
-	public boolean add( Buff buff ) {
+	public boolean add(Buff_Observer buff ) {
 		return false;
 	}
 	

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/npcs/Sheep.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/npcs/Sheep.java
@@ -24,7 +24,7 @@ package com.shatteredpixel.shatteredpixeldungeon.actors.mobs.npcs;
 import com.shatteredpixel.shatteredpixeldungeon.Assets;
 import com.shatteredpixel.shatteredpixeldungeon.Dungeon;
 import com.shatteredpixel.shatteredpixeldungeon.actors.Char;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Buff;
+import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Buff_Observer;
 import com.shatteredpixel.shatteredpixeldungeon.messages.Messages;
 import com.shatteredpixel.shatteredpixeldungeon.sprites.CharSprite;
 import com.shatteredpixel.shatteredpixeldungeon.sprites.SheepSprite;
@@ -70,7 +70,7 @@ public class Sheep extends NPC {
 	}
 
 	@Override
-	public boolean add( Buff buff ) {
+	public boolean add(Buff_Observer buff ) {
 		return false;
 	}
 

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/npcs/Shopkeeper.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/npcs/Shopkeeper.java
@@ -23,10 +23,8 @@ package com.shatteredpixel.shatteredpixeldungeon.actors.mobs.npcs;
 
 import com.shatteredpixel.shatteredpixeldungeon.Dungeon;
 import com.shatteredpixel.shatteredpixeldungeon.ShatteredPixelDungeon;
-import com.shatteredpixel.shatteredpixeldungeon.Statistics;
 import com.shatteredpixel.shatteredpixeldungeon.actors.Char;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.AscensionChallenge;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Buff;
+import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Buff_Observer;
 import com.shatteredpixel.shatteredpixeldungeon.effects.CellEmitter;
 import com.shatteredpixel.shatteredpixeldungeon.effects.particles.ElmoParticle;
 import com.shatteredpixel.shatteredpixeldungeon.items.Heap;
@@ -72,7 +70,7 @@ public class Shopkeeper extends NPC {
 	}
 	
 	@Override
-	public boolean add( Buff buff ) {
+	public boolean add(Buff_Observer buff ) {
 		if (super.add(buff)) {
 			flee();
 			return true;

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/npcs/Wandmaker.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/npcs/Wandmaker.java
@@ -25,7 +25,7 @@ import com.shatteredpixel.shatteredpixeldungeon.Dungeon;
 import com.shatteredpixel.shatteredpixeldungeon.Statistics;
 import com.shatteredpixel.shatteredpixeldungeon.actors.Char;
 import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.AscensionChallenge;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Buff;
+import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Buff_Observer;
 import com.shatteredpixel.shatteredpixeldungeon.items.Generator;
 import com.shatteredpixel.shatteredpixeldungeon.items.Item;
 import com.shatteredpixel.shatteredpixeldungeon.items.quest.CeremonialCandle;
@@ -83,7 +83,7 @@ public class Wandmaker extends NPC {
 	}
 
 	@Override
-	public boolean add( Buff buff ) {
+	public boolean add(Buff_Observer buff ) {
 		return false;
 	}
 	

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/wands/WandOfRegrowth.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/wands/WandOfRegrowth.java
@@ -26,17 +26,7 @@ import com.shatteredpixel.shatteredpixeldungeon.Dungeon;
 import com.shatteredpixel.shatteredpixeldungeon.Statistics;
 import com.shatteredpixel.shatteredpixeldungeon.actors.Actor;
 import com.shatteredpixel.shatteredpixeldungeon.actors.Char;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.AllyBuff;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Amok;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Buff;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Corruption;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Doom;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Dread;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Paralysis;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Roots;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Sleep;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Terror;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Vertigo;
+import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.*;
 import com.shatteredpixel.shatteredpixeldungeon.actors.hero.Hero;
 import com.shatteredpixel.shatteredpixeldungeon.actors.hero.abilities.mage.WildMagic;
 import com.shatteredpixel.shatteredpixeldungeon.actors.mobs.DwarfKing;
@@ -450,7 +440,7 @@ public class WandOfRegrowth extends Wand {
 		}
 
 		@Override
-		public boolean add( Buff buff ) {
+		public boolean add(Buff_Observer buff ) {
 			return false;
 		}
 

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/rooms/special/SentryRoom.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/rooms/special/SentryRoom.java
@@ -27,7 +27,7 @@ import com.shatteredpixel.shatteredpixeldungeon.Challenges;
 import com.shatteredpixel.shatteredpixeldungeon.Dungeon;
 import com.shatteredpixel.shatteredpixeldungeon.actors.Actor;
 import com.shatteredpixel.shatteredpixeldungeon.actors.Char;
-import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Buff;
+import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Buff_Observer;
 import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.LostInventory;
 import com.shatteredpixel.shatteredpixeldungeon.actors.mobs.Eye;
 import com.shatteredpixel.shatteredpixeldungeon.actors.mobs.npcs.NPC;
@@ -305,7 +305,7 @@ public class SentryRoom extends SpecialRoom {
 		}
 
 		@Override
-		public boolean add( Buff buff ) {
+		public boolean add(Buff_Observer buff ) {
 			return false;
 		}
 


### PR DESCRIPTION
# 4주차_buffs_정진규

날짜: 2023년 5월 25일 → 2023년 5월 29일
담당자: 정진규
상태: Done🏠
작성자: 정진규
작업유형: ⚒️디자인패턴

# Commit Message

> 
> 
> 
> Fix: Dip violation
> 
> Fix: Dip violation(Week3_Observer pattern)
> 

# 수정한 파일

> 
> 
> 
> <aside>
> ⚠️ Fix: Dip violation
> 
> [Char.java](http://Char.java)  (폴더 외 변경)
> 
> [actor.java](http://actor.java) (폴더 외 변경)
> 
> Buff_Collection.java   (폴더 내 수정)
> 
> Buff_Observer.java     (폴더 내 수정)
> 
> Build_buff_collection (폴더 내 추가)
> 
> </aside>
> 
> <aside>
> ⚠️ Fix: Erase knowing concrete subject in Client_side
> Buff로 인자받던 부분 ⏩ <interface>인 Buff_Observer로 받도록
> 
> (폴더 외 변경)
> 
> hero/abilities/duelist/Feint.java
> 
> hero/Hero.java
> 
> (폴더 외 변경)
> 
> actors/mobs/npcs/Blacksmith.java
> actors/mobs/npcs/Ghost.java
> actors/mobs/npcs/Imp.java
> actors/mobs/npcs/RatKing.java
> actors/mobs/npcs/Shopkeeper.java
> actors/mobs/npcs/Sheep.java
> actors/mobs/npcs/Wandmaker.java
> 
> (폴더 외 변경)
> 
> actors/mobs/Bee.java
> actors/mobs/Elemental.java
> actors/mobs/Mob.java
> actors/mobs/Mimic.java
> actors/mobs/Pylon.java
> actors/mobs/Tengu.java
> actors/mobs/Statue.java
> 
> (폴더 외 변경)
> 
> items/wands/WandOfRegrowth.java
> 
> (폴더 외 변경)
> levels/rooms/special/SentryRoom.java
> 
> </aside>
> 

# 패턴에 대한 설명

> 
> 
> 
> ## Observer pattern
> 
> ![4-2-Behavioral Pattern-Observer-12.jpg](https://file.notion.so/f/s/ee34e465-8e2e-470f-a480-1cb081a123c9/4-2-Behavioral_Pattern-Observer-12.jpg?id=3689576c-cf78-41ea-946a-be2e767fe5ab&table=block&spaceId=7d682076-1dd7-42aa-abd7-a3f8dd1751c4&expirationTimestamp=1685425214569&signature=Fv29-bQQH5W9mnsj-POnB07R3F5dXg9gTf2fJaGutxM&downloadName=4-2-Behavioral+Pattern-Observer-12.jpg)
> 
> # 이전 week3 에서 Observer pattern 에 대하여 잘못 수행된 부분 재수행
> 

# 수행 이유

> 
> 
> 
> DIP 위반 제거
> 
> 수행후에도 사라지지 않았던 inappropriate intimacy 에대한 재수행
> 

# 효과

> 
> 
> 
> OCP, DIP 충족
> *(Concreate observer의 변경에 대한 OCP 충족)*
> 

# 전/후 비교 다이어그램

> 
> 
> 
> ## 적용 전 다이어그램(최초)
> 
> ![refactoring_before.png](https://file.notion.so/f/s/02a66584-5a59-4d7f-a728-b4123b145c6c/refactoring_before.png?id=4f724658-8d59-407e-b782-0aa4db029168&table=block&spaceId=7d682076-1dd7-42aa-abd7-a3f8dd1751c4&expirationTimestamp=1685425238032&signature=t0Isyyu0TXNjR7KNDZ8IgeqXR8kTL3ptw6Bpz3wmRLg&downloadName=refactoring_before.png)
> 

> 
> 
> 
> ## 적용 전 다이어그램(수행 중)
> 
> ![Buff_mid.png](https://file.notion.so/f/s/d82e0d09-b647-4195-a536-e0ed6e8ce0d7/Buff_mid.png?id=426f8acb-8029-4248-b68c-f12b5e601840&table=block&spaceId=7d682076-1dd7-42aa-abd7-a3f8dd1751c4&expirationTimestamp=1685425257864&signature=xKh7wYjHBQGb8W-LcrmfvovsSW-p4eXZ0wT436Ke44M&downloadName=Buff_mid.png)
> 
> 지난주 수행한 경우 Actor가 고수준 모듈, Buff_collection이 저수준 모듈이라는 시각에서 봤을 때, 
> new를 이용한 초기화를 진행해주는 부분으로 인해,
> 
> 생성자에 대한 dependency가 일어나는 부분을 확인 할 수 있다
> 
> 이는 DIP위반으로 볼수 있다.
> 

> 
> 
> 
> ## 적용 후 다이어그램
> 
> ![Buff_after.png](https://file.notion.so/f/s/5086d19a-aa00-4689-bf76-447d26bee4fc/Buff_after.png?id=27e7863f-ac80-475a-8d9f-7c09e600c1bc&table=block&spaceId=7d682076-1dd7-42aa-abd7-a3f8dd1751c4&expirationTimestamp=1685425377329&signature=nKutp9HEs5fYF4i7r6-EmM6CY11VdJYkINLZ6Vp6HoQ&downloadName=Buff_after.png)
> 
> ![Buff_최종.png](https://file.notion.so/f/s/b9cb3898-a197-4c44-bbb9-6d1dab6582c9/Buff_%EC%B5%9C%EC%A2%85.png?id=1d00821b-7610-4f0c-b1f1-834c5e14d414&table=block&spaceId=7d682076-1dd7-42aa-abd7-a3f8dd1751c4&expirationTimestamp=1685425284959&signature=hUUp_RLvLIqPb2AAAzXlQjBnEpr8N5Z0lgFcCphXEvw&downloadName=Buff_%EC%B5%9C%EC%A2%85.png)
> 
> 상위 모듈(or Class)에서 초기화 하던 부분을 삭제, Dependency를 제거
> 
> 초기화, 생성을 대신 해주는 interface를 추가 및 static으로 메서드를 불러올 수 있게 하여 DIP충족
> 
