### PR TITLE
[Test]: Create a subclass object of Pasty and test some method operation

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -7,5 +7,9 @@ dependencies {
     api project(':SPD-classes')
     implementation project(':services')
     implementation 'junit:junit:4.13.1'
-    implementation 'org.junit.jupiter:junit-jupiter:5.8.1'
+    implementation 'org.junit.jupiter:junit-jupiter:5.9.2'
+    implementation 'org.mockito:mockito-junit-jupiter:5.2.0'
+    implementation 'org.mockito:junit-jupiter:2.20.0'
+    implementation 'name.falgout.jeffrey.testing.junit5:mockito-extension:1.2.1'
+    implementation 'org.mockito:mockito-core:5.2.0'
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/food/PastyTest.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/food/PastyTest.java
@@ -8,6 +8,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 @ExtendWith(MockitoExtension.class)
 class PastyTest {
     /**
@@ -25,6 +27,14 @@ class PastyTest {
     Pasty pastyXmas = Mockito.mock(PastyXMAS.class);
     Pasty pastyNone = Mockito.mock(PastyNONE.class);
     Pasty pastyHween = Mockito.mock(PastyHWEEN.class);
+
+    @Test
+    void newPastyError() {
+        assertAll("Creating Pasty",
+                () -> assertThrows(NullPointerException.class, () -> new Pasty(), "Expected NullPointerException"),
+                () -> assertThrows(ExceptionInInitializerError.class, () -> new Pasty(), "Expected ExceptionInInitializerError")
+        );
+    }
 
     @Test
     void createInstance() {

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/food/PastyTest.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/food/PastyTest.java
@@ -1,0 +1,53 @@
+package com.shatteredpixel.shatteredpixeldungeon.items.food;
+
+import com.shatteredpixel.shatteredpixeldungeon.actors.hero.Hero;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ExtendWith(MockitoExtension.class)
+class PastyTest {
+    /**
+     * Purpose: Creating a subclass of Pasty
+     * Input: Pasty is implemented as a Singleton Design Pattern,
+     *          so an object must be created with the getInstance method.
+     *          However, an object was created using Mockito due to an object creation error.
+     *          A NullPointerException error occurs.
+     *          because the file of the original developer watabo's TextureFile does not exist.
+     *          So, I couldn't create an object,
+     *          So, I created an object using Mock.
+     * Expected: Since we created the object, we check to see if it returns a non-null value.
+     * Using assertNotNull() doesn't throw an error.
+     */
+    Pasty pastyXmas = Mockito.mock(PastyXMAS.class);
+    Pasty pastyNone = Mockito.mock(PastyNONE.class);
+    Pasty pastyHween = Mockito.mock(PastyHWEEN.class);
+
+    @Test
+    void createInstance() {
+        assertNotNull(pastyXmas);
+        assertNotNull(pastyNone);
+        assertNotNull(pastyHween);
+    }
+
+    @Test
+    void reset() {
+        pastyXmas.reset();
+        assertNotNull(pastyHween);
+        pastyNone.reset();
+        assertNotNull(pastyNone.image);
+        pastyHween.reset();
+        assertNotNull(pastyHween.image);
+    }
+
+    @Test
+    void satisfy() {
+        Hero hero = Mockito.mock(Hero.class);
+        pastyXmas.satisfy(hero);
+        pastyNone.satisfy(hero);
+        pastyHween.satisfy(hero);
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,8 +3,8 @@ include ':SPD-classes'
 include ':core'
 
 //platform modules
-include ':android'
-include ':ios'
+//include ':android'
+//include ':ios'
 include ':desktop'
 
 //service modules


### PR DESCRIPTION
[Unit Test]: Create a subclass object of Pasty and test some method operation
# UnitTest 1주차

날짜: 2023년 6월 11일
담당자: 다윗 신
상태: Done🏠
작성자: 신다윗
작업유형: 🔎테스팅

# 작업 유형

> Date: 2023.06.03~2023.06.11
Manager: 신다윗
Status: Done
Writer: 신다윗
Work Type: Test SubClass in Pasty.java
> 

# Testing 적용한 파일 & method

> PastyXMAS.java, PastyNONE.java, PastyHWEEN.java
> 
> - reset()
> - satisfy(Hero)

# Test Coverage 사진

> 
> 
> 
> ![Coverage](https://file.notion.so/f/s/d74021fc-0073-4020-b8ad-b0fb44487056/Untitled.png?id=3a899a7c-2db6-4687-b13c-5ed127e7bef1&table=block&spaceId=7d682076-1dd7-42aa-abd7-a3f8dd1751c4&expirationTimestamp=1686503668637&signature=kGJ9YISYTEDSumB7SM2Rks5jfBlWCFUR4v55y3gXn9g&downloadName=Untitled.png)
> 

# 작업 내용

# Why couldn't I use new Pasty() and Pasty.createInstance()

> After creating a test file from the original file of the original author, if new Pasty() is executed, a .NullPointerException occurs because there is no texture file in the initial creator watabu's code.
> 
> 
> ![Let's trace the error code1](https://file.notion.so/f/s/e6a349b1-2448-48bf-9122-24069bf380b9/Untitled.png?id=e71876cf-87f3-487f-9118-a3bd4c3cb5ed&table=block&spaceId=7d682076-1dd7-42aa-abd7-a3f8dd1751c4&expirationTimestamp=1686503672575&signature=c9bGzlyylFzzxJ757-f_75E9mt9mJrtmsow1JCAicqs&downloadName=Untitled.png)
> 
> Go through the code.
> 
> ![Let's trace the error code2](https://file.notion.so/f/s/c55be52c-92a4-4ea6-a611-4a89e7b35cea/Untitled.png?id=b4e52063-d654-4753-a281-a7dedbd72f23&table=block&spaceId=7d682076-1dd7-42aa-abd7-a3f8dd1751c4&expirationTimestamp=1686503675622&signature=qP9jafzCMutZIfR_kxjPm1pqVeX8gKcTt_SddBYETvA&downloadName=Untitled.png)
> 
> Go through the code.
> 
> ![Let's trace the error code3](https://file.notion.so/f/s/3e681971-c5a2-41a8-8d04-4f483e5509a3/Untitled.png?id=4240af5a-bf21-4795-aa25-2de395477784&table=block&spaceId=7d682076-1dd7-42aa-abd7-a3f8dd1751c4&expirationTimestamp=1686503683653&signature=UxsXHxJnzPDD0jJwDC9dakj8vFFJxAfX01cE1f3whdc&downloadName=Untitled.png)
> 
> Go through the code.
> 
> ![Let's trace the error code4](https://file.notion.so/f/s/a744a9e1-7bde-4790-82d9-43118126277d/Untitled.png?id=ebce7324-4d14-4246-8f93-119bda2b7f32&table=block&spaceId=7d682076-1dd7-42aa-abd7-a3f8dd1751c4&expirationTimestamp=1686503686203&signature=QKcmqJrueJwS88iBi539jYCn-s1KJL4d06R0hmEf9tk&downloadName=Untitled.png)
> 
> static public final String externalPath = System.getProperty("user.home") + File.separator;
> static public final String localPath = new File("").getAbsolutePath() + File.separator;
> When I look at the code above, I think it is in the original author's user.home.
> 
> Error in the picture below
> 
> Cannot invoke "com.badlogic.gdx.Files.internal(String)" because "com.badlogic.gdx.Gdx.files" is null
> 
> ![error description](https://file.notion.so/f/s/e0953bb3-bb14-452c-b316-b8fa7ad51b7f/Untitled.png?id=20733986-97b8-4e42-bd40-00e772c95e6d&table=block&spaceId=7d682076-1dd7-42aa-abd7-a3f8dd1751c4&expirationTimestamp=1686503689221&signature=9ks5uYRt3sxWB90Mdd7GAOcP16CEJczFD6WXQ3VUR7A&downloadName=Untitled.png)
>